### PR TITLE
downgrade elasticsearch-php dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "elasticsearch/elasticsearch": "^6.7",
+        "elasticsearch/elasticsearch": "^6.5",
         "psr/log": "~1.0",
         "ruflin/elastica": "^6.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3929a9ef5d6cd2f64744d4c7fea41d12",
+    "content-hash": "082aba2a142d9420c3478a2141116739",
     "packages": [
         {
             "name": "elasticsearch/elasticsearch",


### PR DESCRIPTION
to be compatible with the [official version matrix](https://github.com/elastic/elasticsearch-php#version-matrix)