### PR TITLE
Added support for dedicated index aliases for read and write operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 ### Added
 ### Improvements
+* Added support for dedicated index aliases for read and write operations (connnection options `index_read` and `index_write`)
 ### Deprecated
 
 ## [1.0.0](https://github.com/kununu/elasticsearch/compare/v0.4-beta...v1.0)

--- a/doc/REPOSITORY.md
+++ b/doc/REPOSITORY.md
@@ -80,7 +80,11 @@ my_second_repo:
 The second constructor argument for every `Repository` is an object/associative array containing all relevant configuration values for the Elasticsearch connection.
 Mandatory fields are
  - `adapter_class`: the fully-qualified class name of the adapter to be built by the `AdapterFactory`
- - `index`: the name of the Elasticsearch index the `Repository` should connect to
+ - `index_read`: the name of the Elasticsearch index the `Repository` should connect to for any read operation (search, count, aggregate)
+ - `index_write`: the name of the Elasticsearch index the `Repository` should connect to for any write operation (save, delete)
  - `type`: the name of the Elasticsearch type the `Repository` should connect to
+
+Optional fields are
+- `index`: the name of the Elasticsearch index the `Repository` should connect to for for any operation. Useful if you are not using aliases. This **does not** override `index_read` and `index_write` if given.
 
 In the future this object might be extended with additional (mandatory) fields.

--- a/doc/REPOSITORY.md
+++ b/doc/REPOSITORY.md
@@ -31,13 +31,14 @@ This package includes a few objects for non-scalar return values of `Elasticsear
 ## Usage
 It's possible to either use the standard `ElasticsearchRepository` directly or to extend this class and use dedicated Repositories for each entity.
 
-Example for a Symfony DI service definition:
+Example for a Symfony DI service definition in a 3rd party project:
 ```yaml
 App\Repository\ElasticSubmissionRepository:
   arguments:
     - '@Kununu\Elasticsearch\Adapter\AdapterFactory'
     - adapter_class: 'Kununu\Elasticsearch\Adapter\ElasticaAdapter'
-      index: 'culture_submissions'
+      index_read: 'culture_submissions_read'
+      index_write: 'culture_submissions_write'
       type: '_doc'
   calls:
     - method: setLogger
@@ -64,7 +65,8 @@ my_first_repo:
   arguments:
     - '@Kununu\Elasticsearch\Adapter\AdapterFactory'
     - adapter_class: 'Kununu\Elasticsearch\Adapter\ElasticsearchAdapter'
-      index: 'some_index'
+      index_read: 'some_index_read'
+      index_write: 'some_index_write'
       type: '_doc'
 
 my_second_repo:

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -20,9 +20,9 @@ abstract class AbstractAdapter
     public const SCROLL_CONTEXT_KEEPALIVE = '1m';
 
     /**
-     * @var string
+     * @var array
      */
-    protected $indexName;
+    protected $index = [];
 
     /**
      * @var string
@@ -30,11 +30,17 @@ abstract class AbstractAdapter
     protected $typeName;
 
     /**
+     * @param string $operation
+     *
      * @return string
      */
-    public function getIndexName(): string
+    public function getIndexName(string $operation): string
     {
-        return $this->indexName;
+        if (isset($this->index[$operation])) {
+            return $this->index[$operation];
+        } else {
+            throw new AdapterConfigurationException('No index name configured for operation "' . $operation . '"');
+        }
     }
 
     /**
@@ -47,8 +53,16 @@ abstract class AbstractAdapter
 
     protected function validateIndexAndType(): void
     {
-        if (empty($this->indexName)) {
-            throw new AdapterConfigurationException('no valid index name defined');
+        if (!is_array($this->index)) {
+            throw new AdapterConfigurationException('no valid index name/alias defined');
+        }
+
+        foreach ([AdapterInterface::OP_READ, AdapterInterface::OP_WRITE] as $operation) {
+            if (empty($this->getIndexName($operation))) {
+                throw new AdapterConfigurationException(
+                    'no valid index name for ' . $operation . ' operations defined'
+                );
+            }
         }
 
         if (empty($this->typeName)) {

--- a/src/Adapter/AdapterFactory.php
+++ b/src/Adapter/AdapterFactory.php
@@ -65,23 +65,34 @@ class AdapterFactory implements LoggerAwareInterface, AdapterFactoryInterface
         switch ($class) {
             case ElasticsearchAdapter::class:
             case ElasticaAdapter::class:
-                /** @var \Kununu\Elasticsearch\Adapter\AdapterInterface $adapter */
-                $adapter = new $class(
-                    $this->clients[$class],
-                    [
-                        'read' => $connectionConfig[self::OPTION_INDEX_READ],
-                        'write' => $connectionConfig[self::OPTION_INDEX_WRITE],
-                    ],
-                    $connectionConfig['type']
-                );
-                if ($adapter instanceof LoggerAwareInterface) {
-                    $adapter->setLogger($this->logger);
-                }
-
-                return $adapter;
+                return $this->doBuildAdapter($class, $connectionConfig);
             default:
                 throw new InvalidArgumentException('Unknown adapter class "' . $class . '"');
         }
+    }
+
+    /**
+     * @param string $class
+     * @param array  $connectionConfig
+     *
+     * @return \Kununu\Elasticsearch\Adapter\AdapterInterface
+     */
+    protected function doBuildAdapter(string $class, array $connectionConfig): AdapterInterface
+    {
+        /** @var \Kununu\Elasticsearch\Adapter\AdapterInterface $adapter */
+        $adapter = new $class(
+            $this->clients[$class],
+            [
+                'read' => $connectionConfig[self::OPTION_INDEX_READ],
+                'write' => $connectionConfig[self::OPTION_INDEX_WRITE],
+            ],
+            $connectionConfig['type']
+        );
+        if ($adapter instanceof LoggerAwareInterface) {
+            $adapter->setLogger($this->logger);
+        }
+
+        return $adapter;
     }
 
     /**

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -14,10 +14,15 @@ use Kununu\Elasticsearch\Result\ResultIteratorInterface;
  */
 interface AdapterInterface
 {
+    public const OP_READ = 'read';
+    public const OP_WRITE = 'write';
+
     /**
+     * @param string $operation
+     *
      * @return string
      */
-    public function getIndexName(): string;
+    public function getIndexName(string $operation): string;
 
     /**
      * @return string

--- a/tests/Adapter/AbstractAdapterTest.php
+++ b/tests/Adapter/AbstractAdapterTest.php
@@ -16,18 +16,18 @@ class AbstractAdapterTest extends MockeryTestCase
     protected const TYPE = '_doc';
 
     /**
-     * @param string|null $index
+     * @param array|null  $index
      * @param string|null $type
      *
      * @return \Kununu\Elasticsearch\Adapter\AbstractAdapter
      */
-    protected function getInstance(?string $index, ?string $type)
+    protected function getInstance(?array $index, ?string $type)
     {
         return new class($index, $type) extends AbstractAdapter
         {
-            public function __construct(?string $index, ?string $type)
+            public function __construct(?array $index, ?string $type)
             {
-                $this->indexName = $index;
+                $this->index = $index;
                 $this->typeName = $type;
 
                 $this->validateIndexAndType();
@@ -38,24 +38,45 @@ class AbstractAdapterTest extends MockeryTestCase
     public function invalidIndexOrTypeData(): array
     {
         return [
-            ['something', null],
+            [['index_read' => '', 'index_write' => 'something'], 'foo'],
+            [['index_read' => 'something', 'index_write' => ''], 'foo'],
+            [['index_read' => '', 'index_write' => ''], 'foo'],
+            [['index_read' => 'something'], 'foo'],
+            [['index_write' => 'something'], 'foo'],
+            [['index_read' => ''], 'foo'],
+            [['index_write' => ''], 'foo'],
+            [[], 'foo'],
             [null, 'foo'],
-            ['something', ''],
-            ['', 'foo'],
-            ['', null],
+            [['index_read' => 'something', 'index_write' => 'something'], ''],
+            [['index_read' => 'something', 'index_write' => 'something'], null],
+            [[], ''],
+            [[], null],
             [null, ''],
             [null, null],
-            ['', ''],
+            [['index_read' => '', 'index_write' => 'something'], ''],
+            [['index_read' => 'something', 'index_write' => ''], ''],
+            [['index_read' => '', 'index_write' => ''], ''],
+            [['index_read' => 'something'], ''],
+            [['index_write' => 'something'], ''],
+            [['index_read' => ''], ''],
+            [['index_write' => ''], ''],
+            [['index_read' => '', 'index_write' => 'something'], null],
+            [['index_read' => 'something', 'index_write' => ''], null],
+            [['index_read' => '', 'index_write' => ''], null],
+            [['index_read' => 'something'], null],
+            [['index_write' => 'something'], null],
+            [['index_read' => ''], null],
+            [['index_write' => ''], null],
         ];
     }
 
     /**
      * @dataProvider invalidIndexOrTypeData
      *
-     * @param string|null $index
+     * @param array|null  $index
      * @param string|null $type
      */
-    public function testInvalidIndexOrType(?string $index, ?string $type): void
+    public function testInvalidIndexOrType(?array $index, ?string $type): void
     {
         $this->expectException(AdapterConfigurationException::class);
 

--- a/tests/Adapter/ElasticsearchAdapterTest.php
+++ b/tests/Adapter/ElasticsearchAdapterTest.php
@@ -21,7 +21,10 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  */
 class ElasticsearchAdapterTest extends MockeryTestCase
 {
-    protected const INDEX = 'some_index';
+    protected const INDEX = [
+        'read' => 'some_index_read',
+        'write' => 'some_index_write',
+    ];
     protected const TYPE = '_doc';
     protected const ID = 'can_be_anything';
     protected const DOCUMENT_COUNT = 42;
@@ -69,7 +72,7 @@ class ElasticsearchAdapterTest extends MockeryTestCase
             ->once()
             ->with(
                 [
-                    'index' => self::INDEX,
+                    'index' => self::INDEX['write'],
                     'type' => self::TYPE,
                     'id' => self::ID,
                     'body' => $document,
@@ -89,7 +92,7 @@ class ElasticsearchAdapterTest extends MockeryTestCase
             ->once()
             ->with(
                 [
-                    'index' => self::INDEX,
+                    'index' => self::INDEX['write'],
                     'type' => self::TYPE,
                     'id' => self::ID,
                 ]
@@ -108,7 +111,7 @@ class ElasticsearchAdapterTest extends MockeryTestCase
             ->once()
             ->with(
                 [
-                    'index' => self::INDEX,
+                    'index' => self::INDEX['write'],
                 ]
             );
 
@@ -116,12 +119,12 @@ class ElasticsearchAdapterTest extends MockeryTestCase
             ->shouldReceive('indices')
             ->andReturn($indicesMock);
 
-        $this->getAdapter()->deleteIndex(self::INDEX);
+        $this->getAdapter()->deleteIndex(self::INDEX['write']);
     }
 
     public function testDeleteIndexOtherIndex(): void
     {
-        $indexToDelete = self::INDEX . '_2';
+        $indexToDelete = self::INDEX['read'] . '_2';
 
         $indicesMock = Mockery::mock(IndicesNamespace::class);
         $indicesMock
@@ -299,7 +302,7 @@ class ElasticsearchAdapterTest extends MockeryTestCase
     public function testSearchByQuery(QueryInterface $query, array $esResult, array $endResult, bool $scroll): void
     {
         $rawParams = [
-            'index' => self::INDEX,
+            'index' => self::INDEX['read'],
             'type' => self::TYPE,
             'body' => $query->toArray(),
         ];
@@ -337,7 +340,7 @@ class ElasticsearchAdapterTest extends MockeryTestCase
             ->once()
             ->with(
                 [
-                    'index' => self::INDEX,
+                    'index' => self::INDEX['read'],
                     'type' => self::TYPE,
                     'body' => $query->toArray(),
                 ]
@@ -352,16 +355,15 @@ class ElasticsearchAdapterTest extends MockeryTestCase
      *
      * @param \Kununu\Elasticsearch\Query\QueryInterface $query
      * @param array                                      $esResult
-     * @param array                                      $endResult
      */
-    public function testAggregate(QueryInterface $query, array $esResult, array $endResult): void
+    public function testAggregate(QueryInterface $query, array $esResult): void
     {
         $this->clientMock
             ->shouldReceive('search')
             ->once()
             ->with(
                 [
-                    'index' => self::INDEX,
+                    'index' => self::INDEX['read'],
                     'type' => self::TYPE,
                     'body' => $query->toArray(),
                 ]
@@ -388,7 +390,7 @@ class ElasticsearchAdapterTest extends MockeryTestCase
     {
         $emptyQuery = Query::create();
         $emptyRawQuery = [
-            'index' => self::INDEX,
+            'index' => self::INDEX['write'],
             'type' => self::TYPE,
             'body' => [],
         ];
@@ -396,7 +398,7 @@ class ElasticsearchAdapterTest extends MockeryTestCase
             Filter::create('foo', 'bar')
         );
         $termRawQuery = [
-            'index' => self::INDEX,
+            'index' => self::INDEX['write'],
             'type' => self::TYPE,
             'body' => [
                 'query' => [


### PR DESCRIPTION
Added connnection options `index_read` and `index_write` for Repositories.

Example for a project configuring a Repository with Symfony Dependency Injection:

Without index aliases (works as before this PR):
```yaml
Kununu\Elasticsearch\Repository\ElasticsearchRepository:
  arguments:
    - '@Kununu\Elasticsearch\Adapter\AdapterFactory'
    - adapter_class: 'Kununu\Elasticsearch\Adapter\ElasticsearchAdapter'
      index: 'my_index'
      type: '_doc'
```

With dedicated aliases for read and write operations:
```yaml
Kununu\Elasticsearch\Repository\ElasticsearchRepository:
  arguments:
    - '@Kununu\Elasticsearch\Adapter\AdapterFactory'
    - adapter_class: 'Kununu\Elasticsearch\Adapter\ElasticsearchAdapter'
      index_read: 'my_index_read'
      index_write: 'my_index_write'
      type: '_doc'
```