### PR TITLE
add post event hooks for write operations (save and delete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file based on the
 * Removed `ElasticaQuery`
 ### Bugfixes
 ### Added
+* `postSave` and `postDelete()` hooks for repositories
 ### Improvements
 ### Deprecated
 

--- a/doc/REPOSITORY.md
+++ b/doc/REPOSITORY.md
@@ -74,7 +74,7 @@ my_second_repo:
       type: '_doc'
 ```
 
-#### Configuration
+### Configuration
 The second constructor argument for every `Repository` is an object/associative array containing all relevant configuration values for the repository.
 Mandatory fields are
  - `index_read`: the name of the Elasticsearch index the `Repository` should connect to for any read operation (search, count, aggregate)
@@ -85,3 +85,10 @@ Optional fields are
 - `index`: the name of the Elasticsearch index the `Repository` should connect to for for any operation. Useful if you are not using aliases. This **does not** override `index_read` and `index_write` if given.
 
 In the future this object might be extended with additional (mandatory) fields.
+
+### Hooks
+`ElasticsearchRepository::postSave()` is called directly after every index operation (i.e. when a document is upserted to Elasticsearch). `ElasticsearchRepository::postDelete()` is called after every delete operation.
+Overwrite these methods in your own Repository classes to hook into these events.
+
+
+Example use case: If you want to write the data to two indexes (when migrating index mappings). 

--- a/src/Repository/ElasticsearchRepository.php
+++ b/src/Repository/ElasticsearchRepository.php
@@ -130,9 +130,20 @@ class ElasticsearchRepository implements ElasticsearchRepositoryInterface, Logge
             $this->client->index(
                 array_merge($this->buildRequestBase(OperationType::WRITE), ['id' => $id, 'body' => $document])
             );
+
+            $this->postSave($id, $document);
         } catch (Exception $e) {
             $this->logErrorAndThrowException($e);
         }
+    }
+
+    /**
+     * @param string $id
+     * @param array  $document
+     */
+    protected function postSave(string $id, array $document): void
+    {
+        // ready to be overwritten :)
     }
 
     /**
@@ -144,9 +155,16 @@ class ElasticsearchRepository implements ElasticsearchRepositoryInterface, Logge
             $this->client->delete(
                 array_merge($this->buildRequestBase(OperationType::WRITE), ['id' => $id])
             );
+
+            $this->postDelete($id);
         } catch (Exception $e) {
             $this->logErrorAndThrowException($e);
         }
+    }
+
+    protected function postDelete(string $id): void
+    {
+        // ready to be overwritten :)
     }
 
     /**


### PR DESCRIPTION
`ElasticsearchRepository::postSave()` is called directly after every index operation (i.e. when a document is upserted to Elasticsearch). `ElasticsearchRepository::postDelete()` is called after every delete operation.
Overwrite these methods in your own Repository classes to hook into these events.


Example use case: If you want to write the data to two indexes (when migrating index mappings). 
