### PR TITLE
be more strict with version of elasticsearch/elasticsearch dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file based on the
 * `postSave` and `postDelete()` hooks for repositories
 * Index management features via `IndexManager`
 ### Improvements
+* Really downgraded dependency `elasticsearch/elasticsearch` from 6.7.* to 6.5.* to be compatible with the [official version matrix](https://github.com/elastic/elasticsearch-php#version-matrix)
 ### Deprecated
 
 ## [1.1](https://github.com/kununu/elasticsearch/compare/v1.0...v1.1)

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "elasticsearch/elasticsearch": "^6.5",
+        "elasticsearch/elasticsearch": "~6.5.0",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de781c4a194fdfffa43f5504306cee62",
+    "content-hash": "b1385f842c3a63789f0890a05746b0d3",
     "packages": [
         {
             "name": "elasticsearch/elasticsearch",
-            "version": "v6.7.2",
+            "version": "v6.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elastic/elasticsearch-php.git",
-                "reference": "9ba89f905ebf699e72dacffa410331c7fecc8255"
+                "reference": "0c93d0e5b852634159d9f349b1848acde845400b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/9ba89f905ebf699e72dacffa410331c7fecc8255",
-                "reference": "9ba89f905ebf699e72dacffa410331c7fecc8255",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/0c93d0e5b852634159d9f349b1848acde845400b",
+                "reference": "0c93d0e5b852634159d9f349b1848acde845400b",
                 "shasum": ""
             },
             "require": {
@@ -27,7 +27,7 @@
                 "psr/log": "~1.0"
             },
             "require-dev": {
-                "cpliakas/git-wrapper": "^1.7 || ^2.1",
+                "cpliakas/git-wrapper": "~1.0",
                 "doctrine/inflector": "^1.1",
                 "mockery/mockery": "^1.2",
                 "phpstan/phpstan-shim": "^0.9 || ^0.11",
@@ -64,7 +64,7 @@
                 "elasticsearch",
                 "search"
             ],
-            "time": "2019-07-19T14:48:24+00:00"
+            "time": "2019-07-19T13:34:35+00:00"
         },
         {
             "name": "guzzlehttp/ringphp",


### PR DESCRIPTION
* (now really) downgraded dependency `elasticsearch/elasticsearch` from 6.7.* to 6.5.* to be compatible with the [official version matrix](https://github.com/elastic/elasticsearch-php#version-matrix)