### PR TITLE
Entity Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@ All notable changes to this project will be documented in this file based on the
 * Removed method `ElasticsearchRepository::deleteIndex()` in favor of `IndexManager::deleteIndex()`
 * Renamed `ElasticsearchRepository` to `Repository`
 * Renamed `ElasticsearchRepositoryInterface` to `RepositoryInterface`
+* Changed signature of `RepositoryInterface::save()` and therefore `Repository::save()`
 ### Bugfixes
 ### Added
 * `postSave` and `postDelete()` hooks for repositories
 * Index management features via `IndexManager`
-* added `entity_serializer` and `entity_factory` options to `RepositoryConfiguration`
+* Entity factory for repositories: if configured with an entity factory, a repository will emit entity objects instead of plain document arrays
+* Entity serializer for repositories: if configured with an entity serializer, a repository accepts objects on the `save()` method and serializes them using the given serializer 
 ### Improvements
 * Really downgraded dependency `elasticsearch/elasticsearch` from 6.7.* to 6.5.* to be compatible with the [official version matrix](https://github.com/elastic/elasticsearch-php#version-matrix)
+* fixed a few tests to be more precise
 ### Deprecated
 
 ## [1.1](https://github.com/kununu/elasticsearch/compare/v1.0...v1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 * `postSave` and `postDelete()` hooks for repositories
 * Index management features via `IndexManager`
+* Entity class for repositories: if configured with an entity class, a repository will emit entity objects of this type instead of plain documents and accepts such objects on the `save()` method
 * Entity factory for repositories: if configured with an entity factory, a repository will emit entity objects instead of plain document arrays
 * Entity serializer for repositories: if configured with an entity serializer, a repository accepts objects on the `save()` method and serializes them using the given serializer 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 * `postSave` and `postDelete()` hooks for repositories
 * Index management features via `IndexManager`
+* added `entity_serializer` and `entity_factory` options to `RepositoryConfiguration`
 ### Improvements
 * Really downgraded dependency `elasticsearch/elasticsearch` from 6.7.* to 6.5.* to be compatible with the [official version matrix](https://github.com/elastic/elasticsearch-php#version-matrix)
 ### Deprecated

--- a/doc/REPOSITORY.md
+++ b/doc/REPOSITORY.md
@@ -85,6 +85,8 @@ Mandatory fields are
 
 Optional fields are
 - `index`: the name of the Elasticsearch index the `Repository` should connect to for for any operation. Useful if you are not using aliases. This **does not** override `index_read` and `index_write` if given.
+- `entity_factory`: must be of type `EntityFactoryInterface`. If given, the Repository will emit entities instead of plain document arrays.
+- `entity_serializer`: must be of type `EntitySerializerInterface`. If given, the Repository accepts objects on the `save()` method and serializes them using the given serializer. 
 
 In the future this object might be extended with additional (mandatory) fields.
 

--- a/doc/REPOSITORY.md
+++ b/doc/REPOSITORY.md
@@ -31,7 +31,7 @@ Repositories are `LoggerAware` (see `\Psr\Log\LoggerAwareInterface`).
 This package includes a few objects for non-scalar return values of `ElasticsearchRepository`. Those are: `ResultIterator` and `AggregationResultSet`. See [Results](RESULTS.md) for details.
 
 ## Usage
-It's possible to either use the standard `ElasticsearchRepository` directly or to extend this class and use dedicated Repositories for each entity.
+It's possible to either use the standard `Repository` directly or to extend this class and use dedicated Repositories for each entity.
 
 Example for a Symfony DI service definition in a 3rd party project:
 ```yaml
@@ -85,14 +85,96 @@ Mandatory fields are
 
 Optional fields are
 - `index`: the name of the Elasticsearch index the `Repository` should connect to for for any operation. Useful if you are not using aliases. This **does not** override `index_read` and `index_write` if given.
-- `entity_factory`: must be of type `EntityFactoryInterface`. If given, the Repository will emit entities instead of plain document arrays.
-- `entity_serializer`: must be of type `EntitySerializerInterface`. If given, the Repository accepts objects on the `save()` method and serializes them using the given serializer. 
+- `entity_factory`: must be of type `EntityFactoryInterface`. If given, the repository will emit entities instead of plain document arrays.
+- `entity_serializer`: must be of type `EntitySerializerInterface`. If given, the repository accepts objects on the `save()` method and serializes them using the given serializer. 
 
 In the future this object might be extended with additional (mandatory) fields.
 
+### Working with entities
+By default a repository uses plain document arrays as input when persisting with `save()` and emits `ResultIterator` objects containing plain document arrays when searching.
+
+However, in a lot of cases you will want to work with entity objects to not mess around with plain arrays. This package offers two solutions to this:
+### PersistableEntityInterface
+The simplest solution is to make your entities implement the `PersistableEntityInterface` that comes with this package. It defines two methods:
+ - a static factory method to create an entity from a raw Elasticsearch document
+ - a serializer method which is supposed to convert your entity object to a plain array/document
+
+This solution is suitable for entities which can be easily persisted in Elasticsearch as-is.
+
+### EntitySerializer and EntityFactory
+There are more advanced use cases in which an entity does not have direct access to all data required to serialize it into an Elasticsearch document. Example: entities stored in a normalized fashion in a relational DBMS. In Elasticsearch, however, a denormalized version of the data should be stored for easy retrieval.
+
+In such a case you will require additional information (more than is available in the entity object itself) when persisting an entity in Elasticsearch.
+
+Simply configure your repository with the `entity_serializer` option by passing an instance of a class implementing `EntitySerializerInterface`:
+```php
+class MyDomainEntitySerializer implements EntitySerializerInterface {
+    public function __construct(/* all my dependencies */) {
+        // ...
+    }
+    public function toElastic($entity): array {
+        // compose your document here
+    
+        return $document;
+    }
+}
+
+$mySerializer = new MyDomainEntitySerializer(/* ... */);
+
+$repository = new Repository(
+    $client,
+    [
+        'index' => 'my_index',
+        'type' => '_doc',
+        'entity_serializer' => $mySerializer,
+    ]
+);
+
+$myEntity = new DomainEntity();
+
+// the repository will use $mySerializer to convert $myEntity to a plain array before persisting it to Elasticsearch
+$repository->save('my_first_doc', $myEntity);
+```
+
+Retrieving entity objects from Elasticsearch through a repository is just as simple.
+Configure your repository with the `entity_factory` option by passing an instance of a class implementing `EntityFactoryInterface`:
+```php
+class MyDomainEntityFactory implements EntityFactoryInterface {
+    public function fromDocument(array $document, array $metaData) {
+        $myEntity = new DomainEntity();
+
+        // $document contains the raw document as found in the _source field of the raw Elasticsearch response       
+        $myEntity->setFoo($document['foo'] ?? null);
+        $myEntity->setBar($document['bar'] ?? false);
+
+        // $metaData contains all "underscore-fields" delivered in the raw Elasticsearch response
+        // f.e. _index, _type, _score
+        $myEntity->setSearchResultScore($metaData['_score']);
+
+        return $myEntity;
+    }
+}
+
+$repository = new Repository(
+    $client,
+    [
+        'index' => 'my_index',
+        'type' => '_doc',
+        'entity_factory' => new MyDomainEntityFactory(),
+    ]
+);
+
+$results = $repository->findByQuery(
+    Query::create(Search::create(['text_field'], 'search term'))
+);
+
+// this will be an instance of DomainEntity instead of a plain array
+var_dump($results[0]);
+```
+
 ### Hooks
 `ElasticsearchRepository::postSave()` is called directly after every index operation (i.e. when a document is upserted to Elasticsearch). `ElasticsearchRepository::postDelete()` is called after every delete operation.
-Overwrite these methods in your own Repository classes to hook into these events.
+Overwrite these methods in your own repository classes to hook into these events.
 
 
 Example use case: If you want to write the data to two indexes (when migrating index mappings). 

--- a/src/Repository/EntityFactoryInterface.php
+++ b/src/Repository/EntityFactoryInterface.php
@@ -11,8 +11,8 @@ namespace Kununu\Elasticsearch\Repository;
 interface EntityFactoryInterface
 {
     /**
-     * @param array $document
-     * @param array $metaData
+     * @param array $document the raw document as found in the _source field of the raw Elasticsearch response
+     * @param array $metaData contains all "underscore-fields" delivered in the raw Elasticsearch response (e.g. _score)
      *
      * @return mixed
      */

--- a/src/Repository/EntityFactoryInterface.php
+++ b/src/Repository/EntityFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Elasticsearch\Repository;
+
+/**
+ * Interface EntityFactoryInterface
+ *
+ * @package Kununu\Elasticsearch\Repository
+ */
+interface EntityFactoryInterface
+{
+    /**
+     * @param array $document
+     * @param array $metaData
+     *
+     * @return mixed
+     */
+    public function fromDocument(array $document, array $metaData);
+}

--- a/src/Repository/EntitySerializerInterface.php
+++ b/src/Repository/EntitySerializerInterface.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Elasticsearch\Repository;
+
+/**
+ * Interface EntitySerializerInterface
+ *
+ * @package Kununu\Elasticsearch\Repository
+ */
+interface EntitySerializerInterface
+{
+    /**
+     * @param mixed $entity
+     *
+     * @return array
+     */
+    public function toElastic($entity): array;
+}

--- a/src/Repository/PersistableEntityInterface.php
+++ b/src/Repository/PersistableEntityInterface.php
@@ -21,5 +21,5 @@ interface PersistableEntityInterface
      *
      * @return mixed
      */
-    public function fromElasticDocument(array $document, array $metaData);
+    public static function fromElasticDocument(array $document, array $metaData);
 }

--- a/src/Repository/PersistableEntityInterface.php
+++ b/src/Repository/PersistableEntityInterface.php
@@ -16,8 +16,8 @@ interface PersistableEntityInterface
     public function toElastic(): array;
 
     /**
-     * @param array $document
-     * @param array $metaData
+     * @param array $document the raw document as found in the _source field of the raw Elasticsearch response
+     * @param array $metaData contains all "underscore-fields" delivered in the raw Elasticsearch response (e.g. _score)
      *
      * @return mixed
      */

--- a/src/Repository/PersistableEntityInterface.php
+++ b/src/Repository/PersistableEntityInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Elasticsearch\Repository;
+
+/**
+ * Interface PersistableEntityInterface
+ *
+ * @package Kununu\Elasticsearch\Repository
+ */
+interface PersistableEntityInterface
+{
+    /**
+     * @return array
+     */
+    public function toElastic(): array;
+
+    /**
+     * @param array $document
+     * @param array $metaData
+     *
+     * @return mixed
+     */
+    public function fromElasticDocument(array $document, array $metaData);
+}

--- a/src/Repository/RepositoryConfiguration.php
+++ b/src/Repository/RepositoryConfiguration.php
@@ -16,6 +16,8 @@ class RepositoryConfiguration
     protected const OPTION_INDEX_READ = 'index_read';
     protected const OPTION_INDEX_WRITE = 'index_write';
     protected const OPTION_TYPE = 'type';
+    protected const OPTION_ENTITY_SERIALIZER = 'entity_serializer';
+    protected const OPTION_ENTITY_FACTORY = 'entity_factory';
 
     /**
      * 1 minute per default
@@ -35,21 +37,23 @@ class RepositoryConfiguration
     protected $type;
 
     /**
+     * @var \Kununu\Elasticsearch\Repository\EntitySerializerInterface
+     */
+    protected $entitySerializer;
+
+    /**
+     * @var \Kununu\Elasticsearch\Repository\EntityFactoryInterface
+     */
+    protected $entityFactory;
+
+    /**
      * RepositoryConfiguration constructor.
      *
      * @param array $config
      */
     public function __construct(array $config)
     {
-        $config = $this->inflateConfig($config);
-
-        $this->index = array_filter(
-            [
-                OperationType::READ => $config[static::OPTION_INDEX_READ] ?? null,
-                OperationType::WRITE => $config[static::OPTION_INDEX_WRITE] ?? null,
-            ]
-        );
-        $this->type = $config[static::OPTION_TYPE] ?? null;
+        $this->parseConfig($this->inflateConfig($config));
     }
 
     /**
@@ -76,10 +80,26 @@ class RepositoryConfiguration
     public function getType(): string
     {
         if (!$this->type) {
-            throw new RepositoryConfigurationException('No valid type configured ');
+            throw new RepositoryConfigurationException('No valid type configured');
         }
 
         return $this->type;
+    }
+
+    /**
+     * @return \Kununu\Elasticsearch\Repository\EntitySerializerInterface|null
+     */
+    public function getEntitySerializer(): ?EntitySerializerInterface
+    {
+        return $this->entitySerializer;
+    }
+
+    /**
+     * @return \Kununu\Elasticsearch\Repository\EntityFactoryInterface|null
+     */
+    public function getEntityFactory(): ?EntityFactoryInterface
+    {
+        return $this->entityFactory;
     }
 
     /**
@@ -88,6 +108,38 @@ class RepositoryConfiguration
     public function getScrollContextKeepalive(): string
     {
         return static::DEFAULT_SCROLL_CONTEXT_KEEPALIVE;
+    }
+
+    /**
+     * @param array $config
+     */
+    protected function parseConfig(array $config): void
+    {
+        $this->index = array_filter(
+            [
+                OperationType::READ => $config[static::OPTION_INDEX_READ] ?? null,
+                OperationType::WRITE => $config[static::OPTION_INDEX_WRITE] ?? null,
+            ]
+        );
+        $this->type = $config[static::OPTION_TYPE] ?? null;
+
+        if (isset($config[static::OPTION_ENTITY_SERIALIZER])) {
+            if (!($config[static::OPTION_ENTITY_SERIALIZER] instanceof EntitySerializerInterface)) {
+                throw new RepositoryConfigurationException(
+                    'Invalid entity serializer given. Must be of type \Kununu\Elasticsearch\Repository\EntitySerializerInterface'
+                );
+            }
+            $this->entitySerializer = $config[static::OPTION_ENTITY_SERIALIZER];
+        }
+
+        if (isset($config[static::OPTION_ENTITY_FACTORY])) {
+            if (!($config[static::OPTION_ENTITY_FACTORY] instanceof EntityFactoryInterface)) {
+                throw new RepositoryConfigurationException(
+                    'Invalid entity factory given. Must be of type \Kununu\Elasticsearch\Repository\EntityFactoryInterface'
+                );
+            }
+            $this->entityFactory = $config[static::OPTION_ENTITY_FACTORY];
+        }
     }
 
     /**

--- a/src/Repository/RepositoryConfiguration.php
+++ b/src/Repository/RepositoryConfiguration.php
@@ -138,40 +138,36 @@ class RepositoryConfiguration
         $this->type = $config[static::OPTION_TYPE] ?? null;
 
         if (isset($config[static::OPTION_ENTITY_CLASS])) {
-            $entityClass = $config[static::OPTION_ENTITY_CLASS];
-            if (!class_exists($entityClass)) {
+            $this->entityClass = $config[static::OPTION_ENTITY_CLASS];
+            if (!class_exists($this->entityClass)) {
                 throw new RepositoryConfigurationException(
                     'Given entity class does not exist.'
                 );
             }
 
-            if (!is_a($entityClass, PersistableEntityInterface::class, true)) {
+            if (!is_a($this->entityClass, PersistableEntityInterface::class, true)) {
                 throw new RepositoryConfigurationException(
                     'Invalid entity class given. Must be of type \Kununu\Elasticsearch\Repository\PersistableEntityInterface'
                 );
             }
-
-            $this->entityClass = $entityClass;
         }
 
         if (isset($config[static::OPTION_ENTITY_SERIALIZER])) {
-            $entitySerializer = $config[static::OPTION_ENTITY_SERIALIZER];
-            if (!($entitySerializer instanceof EntitySerializerInterface)) {
+            $this->entitySerializer = $config[static::OPTION_ENTITY_SERIALIZER];
+            if (!($this->entitySerializer instanceof EntitySerializerInterface)) {
                 throw new RepositoryConfigurationException(
                     'Invalid entity serializer given. Must be of type \Kununu\Elasticsearch\Repository\EntitySerializerInterface'
                 );
             }
-            $this->entitySerializer = $entitySerializer;
         }
 
         if (isset($config[static::OPTION_ENTITY_FACTORY])) {
-            $entityFactory = $config[static::OPTION_ENTITY_FACTORY];
-            if (!($entityFactory instanceof EntityFactoryInterface)) {
+            $this->entityFactory = $config[static::OPTION_ENTITY_FACTORY];
+            if (!($this->entityFactory instanceof EntityFactoryInterface)) {
                 throw new RepositoryConfigurationException(
                     'Invalid entity factory given. Must be of type \Kununu\Elasticsearch\Repository\EntityFactoryInterface'
                 );
             }
-            $this->entityFactory = $entityFactory;
         }
     }
 

--- a/src/Repository/RepositoryConfiguration.php
+++ b/src/Repository/RepositoryConfiguration.php
@@ -18,6 +18,7 @@ class RepositoryConfiguration
     protected const OPTION_TYPE = 'type';
     protected const OPTION_ENTITY_SERIALIZER = 'entity_serializer';
     protected const OPTION_ENTITY_FACTORY = 'entity_factory';
+    protected const OPTION_ENTITY_CLASS = 'entity_class';
 
     /**
      * 1 minute per default
@@ -45,6 +46,11 @@ class RepositoryConfiguration
      * @var \Kununu\Elasticsearch\Repository\EntityFactoryInterface
      */
     protected $entityFactory;
+
+    /**
+     * @var string
+     */
+    protected $entityClass;
 
     /**
      * RepositoryConfiguration constructor.
@@ -87,6 +93,14 @@ class RepositoryConfiguration
     }
 
     /**
+     * @return string|null
+     */
+    public function getEntityClass(): ?string
+    {
+        return $this->entityClass;
+    }
+
+    /**
      * @return \Kununu\Elasticsearch\Repository\EntitySerializerInterface|null
      */
     public function getEntitySerializer(): ?EntitySerializerInterface
@@ -123,22 +137,41 @@ class RepositoryConfiguration
         );
         $this->type = $config[static::OPTION_TYPE] ?? null;
 
+        if (isset($config[static::OPTION_ENTITY_CLASS])) {
+            $entityClass = $config[static::OPTION_ENTITY_CLASS];
+            if (!class_exists($entityClass)) {
+                throw new RepositoryConfigurationException(
+                    'Given entity class does not exist.'
+                );
+            }
+
+            if (!is_a($entityClass, PersistableEntityInterface::class, true)) {
+                throw new RepositoryConfigurationException(
+                    'Invalid entity class given. Must be of type \Kununu\Elasticsearch\Repository\PersistableEntityInterface'
+                );
+            }
+
+            $this->entityClass = $entityClass;
+        }
+
         if (isset($config[static::OPTION_ENTITY_SERIALIZER])) {
-            if (!($config[static::OPTION_ENTITY_SERIALIZER] instanceof EntitySerializerInterface)) {
+            $entitySerializer = $config[static::OPTION_ENTITY_SERIALIZER];
+            if (!($entitySerializer instanceof EntitySerializerInterface)) {
                 throw new RepositoryConfigurationException(
                     'Invalid entity serializer given. Must be of type \Kununu\Elasticsearch\Repository\EntitySerializerInterface'
                 );
             }
-            $this->entitySerializer = $config[static::OPTION_ENTITY_SERIALIZER];
+            $this->entitySerializer = $entitySerializer;
         }
 
         if (isset($config[static::OPTION_ENTITY_FACTORY])) {
-            if (!($config[static::OPTION_ENTITY_FACTORY] instanceof EntityFactoryInterface)) {
+            $entityFactory = $config[static::OPTION_ENTITY_FACTORY];
+            if (!($entityFactory instanceof EntityFactoryInterface)) {
                 throw new RepositoryConfigurationException(
                     'Invalid entity factory given. Must be of type \Kununu\Elasticsearch\Repository\EntityFactoryInterface'
                 );
             }
-            $this->entityFactory = $config[static::OPTION_ENTITY_FACTORY];
+            $this->entityFactory = $entityFactory;
         }
     }
 

--- a/src/Repository/RepositoryInterface.php
+++ b/src/Repository/RepositoryInterface.php
@@ -15,10 +15,10 @@ use Kununu\Elasticsearch\Result\ResultIteratorInterface;
 interface RepositoryInterface
 {
     /**
-     * @param string $id
-     * @param array  $document
+     * @param string       $id
+     * @param array|object $entity
      */
-    public function save(string $id, array $document): void;
+    public function save(string $id, $entity): void;
 
     /**
      * @param string $id

--- a/tests/Repository/RepositoryConfigurationTest.php
+++ b/tests/Repository/RepositoryConfigurationTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Kununu\Elasticsearch\Tests\Repository;
 
 use Kununu\Elasticsearch\Exception\RepositoryConfigurationException;
+use Kununu\Elasticsearch\Repository\EntityFactoryInterface;
+use Kununu\Elasticsearch\Repository\EntitySerializerInterface;
 use Kununu\Elasticsearch\Repository\OperationType;
 use Kununu\Elasticsearch\Repository\RepositoryConfiguration;
 use PHPUnit\Framework\TestCase;
@@ -20,7 +22,7 @@ class RepositoryConfigurationTest extends TestCase
     /**
      * @return array
      */
-    public function configData(): array
+    public function inflatableConfigData(): array
     {
         return [
             'only index name given' => [
@@ -56,7 +58,7 @@ class RepositoryConfigurationTest extends TestCase
     }
 
     /**
-     * @dataProvider configData
+     * @dataProvider inflatableConfigData
      *
      * @param array  $input
      * @param string $expectedReadAlias
@@ -135,7 +137,7 @@ class RepositoryConfigurationTest extends TestCase
                 'input' => ['type' => ''],
             ],
             'null type name given' => [
-                'input' => ['index' => null],
+                'input' => ['type' => null],
             ],
         ];
     }
@@ -153,5 +155,59 @@ class RepositoryConfigurationTest extends TestCase
         $this->expectExceptionMessage('No valid type configured');
 
         $config->getType();
+    }
+
+    public function testValidEntitySerializer(): void
+    {
+        $mySerializer = new class implements EntitySerializerInterface
+        {
+            public function toElastic($entity): array
+            {
+                return [];
+            }
+        };
+
+        $config = new RepositoryConfiguration(['entity_serializer' => $mySerializer]);
+
+        $this->assertEquals($mySerializer, $config->getEntitySerializer());
+    }
+
+    public function testInvalidEntitySerializer(): void
+    {
+        $mySerializer = new \stdClass();
+
+        $this->expectException(RepositoryConfigurationException::class);
+        $this->expectExceptionMessage(
+            'Invalid entity serializer given. Must be of type \Kununu\Elasticsearch\Repository\EntitySerializerInterface'
+        );
+
+        $config = new RepositoryConfiguration(['entity_serializer' => $mySerializer]); // NOSONAR
+    }
+
+    public function testValidEntityFactory(): void
+    {
+        $myFactory = new class implements EntityFactoryInterface
+        {
+            public function fromDocument(array $document, array $metaData)
+            {
+                return null;
+            }
+        };
+
+        $config = new RepositoryConfiguration(['entity_factory' => $myFactory]);
+
+        $this->assertEquals($myFactory, $config->getEntityFactory());
+    }
+
+    public function testInvalidEntityFactory(): void
+    {
+        $myFactory = new \stdClass();
+
+        $this->expectException(RepositoryConfigurationException::class);
+        $this->expectExceptionMessage(
+            'Invalid entity factory given. Must be of type \Kununu\Elasticsearch\Repository\EntityFactoryInterface'
+        );
+
+        $config = new RepositoryConfiguration(['entity_factory' => $myFactory]); // NOSONAR
     }
 }


### PR DESCRIPTION
* Entity class for repositories: if configured with an entity class, a repository will emit entity objects of this type instead of plain documents and accepts such objects on the `save()` method
* Entity factory for repositories: if configured with an entity factory, a repository will emit entity objects instead of plain document arrays
* Entity serializer for repositories: if configured with an entity serializer, a repository accepts objects on the `save()` method and serializes them using the given serializer