### PR TITLE
allow objects to be pushed into ResultIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/kununu/elasticsearch/compare/v2.1.1...master)
+## [Unreleased](https://github.com/kununu/elasticsearch/compare/v2.1.2...master)
 ### Backward Compatibility Breaks
 ### Bugfixes
+### Added
+### Improvements
+### Deprecated
+
+## [2.1.2](https://github.com/kununu/elasticsearch/compare/v2.1.1...v2.1.2)
+### Backward Compatibility Breaks
+### Bugfixes
+* allow objects to be pushed into `ResultIterator`
 ### Added
 ### Improvements
 ### Deprecated

--- a/src/Result/ResultIterator.php
+++ b/src/Result/ResultIterator.php
@@ -102,11 +102,11 @@ class ResultIterator implements \Iterator, \ArrayAccess, \Countable, ResultItera
     }
 
     /**
-     * @param array $result
+     * @param array|object $result
      *
      * @return \Kununu\Elasticsearch\Result\ResultIteratorInterface
      */
-    public function push(array $result): ResultIteratorInterface
+    public function push($result): ResultIteratorInterface
     {
         $this->results[] = $result;
 

--- a/tests/Result/ResultIteratorTest.php
+++ b/tests/Result/ResultIteratorTest.php
@@ -123,7 +123,7 @@ class ResultIteratorTest extends MockeryTestCase
         $this->assertEquals(200, $iterator->getTotal());
     }
 
-    public function testPush(): void
+    public function testPushArray(): void
     {
         $iterator = ResultIterator::create();
         $this->assertEmpty($iterator->asArray());
@@ -132,6 +132,18 @@ class ResultIteratorTest extends MockeryTestCase
         $iterator->push(['some' => 'thing']);
 
         $this->assertEquals([['some' => 'thing']], $iterator->asArray());
+        $this->assertEquals(1, $iterator->getCount());
+    }
+
+    public function testPushObject(): void
+    {
+        $iterator = ResultIterator::create();
+        $this->assertEmpty($iterator->asArray());
+        $this->assertEquals(0, $iterator->getCount());
+
+        $iterator->push(new \stdClass());
+
+        $this->assertEquals([new \stdClass()], $iterator->asArray());
         $this->assertEquals(1, $iterator->getCount());
     }
 


### PR DESCRIPTION
Fixed latent issue when using Entity-aware instances of `Repository`.
Even though this was not an issue for the `Repository` as it uses the `ResultIterator::create()` factory method only, this could have case issues for other use cases of the `ResultIterator`.