### PR TITLE
Throw more specific exception when trying to delete non existent documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 ### Deprecated
 
+## [2.4.1](https://github.com/kununu/elasticsearch/compare/v2.4.0...v2.4.1)
+### Backward Compatibility Breaks
+### Bugfixes
+### Added
+### Improvements
+* Distinguish `DocumentNotFoundException` from generic `DeleteException` when trying to delete non-existent documents via `Repository::delete()`
+### Deprecated
+
 ## [2.4.0](https://github.com/kununu/elasticsearch/compare/v2.3.3...v2.4.0)
 ### Backward Compatibility Breaks
 ### Bugfixes

--- a/src/Exception/DeleteException.php
+++ b/src/Exception/DeleteException.php
@@ -6,7 +6,7 @@ namespace Kununu\Elasticsearch\Exception;
 use Throwable;
 
 /**
- * Class WriteException
+ * Class DeleteException
  *
  * @package Kununu\Elasticsearch\Exception
  */

--- a/src/Exception/DocumentNotFoundException.php
+++ b/src/Exception/DocumentNotFoundException.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Elasticsearch\Exception;
+
+use Throwable;
+
+/**
+ * Class DocumentNotFoundException
+ *
+ * @package Kununu\Elasticsearch\Exception
+ */
+class DocumentNotFoundException extends DeleteException
+{
+    /**
+     * @var mixed
+     */
+    protected $documentId;
+
+    /**
+     * @param string          $message
+     * @param \Throwable|null $previous
+     * @param mixed           $documentId
+     */
+    public function __construct($message = "", Throwable $previous = null, $documentId = null)
+    {
+        parent::__construct($message, $previous);
+
+        $this->documentId = $documentId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDocumentId()
+    {
+        return $this->documentId;
+    }
+
+}

--- a/src/Exception/ReadOperationException.php
+++ b/src/Exception/ReadOperationException.php
@@ -6,7 +6,7 @@ namespace Kununu\Elasticsearch\Exception;
 use Throwable;
 
 /**
- * Class ReadException
+ * Class ReadOperationException
  *
  * @package Kununu\Elasticsearch\Exception
  */

--- a/src/Exception/UpsertException.php
+++ b/src/Exception/UpsertException.php
@@ -6,7 +6,7 @@ namespace Kununu\Elasticsearch\Exception;
 use Throwable;
 
 /**
- * Class WriteException
+ * Class UpsertException
  *
  * @package Kununu\Elasticsearch\Exception
  */

--- a/src/Exception/WriteOperationException.php
+++ b/src/Exception/WriteOperationException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Kununu\Elasticsearch\Exception;
 
 /**
- * Class WriteException
+ * Class WriteOperationException
  *
  * @package Kununu\Elasticsearch\Exception
  */

--- a/tests/Repository/RepositoryTest.php
+++ b/tests/Repository/RepositoryTest.php
@@ -325,7 +325,7 @@ class RepositoryTest extends MockeryTestCase
                 self::ID
             );
         } catch (DocumentNotFoundException $e) {
-            $this->assertEquals('No document found with id ' . self::ID, $e->getMessage());
+            $this->assertEquals(self::ERROR_PREFIX . 'No document found with id ' . self::ID, $e->getMessage());
             $this->assertEquals(0, $e->getCode());
             $this->assertEquals(self::ID, $e->getDocumentId());
         }


### PR DESCRIPTION
Distinguish `DocumentNotFoundException` from generic `DeleteException` when trying to delete non-existent documents via `Repository::delete()`