### PR TITLE
introduce term query specifically for search context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 ### Added
 ### Improvements
+* Introduce term query specifically for search context
 ### Deprecated
 
 ## [2.4.1](https://github.com/kununu/elasticsearch/compare/v2.4.0...v2.4.1)

--- a/src/Query/Criteria/Search.php
+++ b/src/Query/Criteria/Search.php
@@ -8,6 +8,8 @@ use Kununu\Elasticsearch\Query\Criteria\Search\Match;
 use Kununu\Elasticsearch\Query\Criteria\Search\MatchPhrase;
 use Kununu\Elasticsearch\Query\Criteria\Search\MatchPhrasePrefix;
 use Kununu\Elasticsearch\Query\Criteria\Search\QueryString;
+use Kununu\Elasticsearch\Query\Criteria\Search\Term;
+use Kununu\Elasticsearch\Query\Criteria\Search\Terms;
 use Kununu\Elasticsearch\Util\ConstantContainerTrait;
 use LogicException;
 
@@ -24,6 +26,7 @@ class Search implements SearchInterface
     public const MATCH_PHRASE = MatchPhrase::KEYWORD;
     public const MATCH_PHRASE_PREFIX = MatchPhrasePrefix::KEYWORD;
     public const QUERY_STRING = QueryString::KEYWORD;
+    public const TERM = Term::KEYWORD;
 
     /**
      * @var array
@@ -113,6 +116,9 @@ class Search implements SearchInterface
                 break;
             case static::MATCH_PHRASE_PREFIX:
                 $query = MatchPhrasePrefix::asArray($this->fields, $this->queryString, $this->options);
+                break;
+            case static::TERM:
+                $query = Term::asArray($this->fields[0], $this->queryString, $this->options);
                 break;
             default:
                 throw new LogicException(

--- a/src/Query/Criteria/Search/Term.php
+++ b/src/Query/Criteria/Search/Term.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Elasticsearch\Query\Criteria\Search;
+
+/**
+ * Class Term
+ *
+ * @package Kununu\Elasticsearch\Query\Criteria\Search
+ */
+class Term
+{
+    public const KEYWORD = 'term';
+
+    /**
+     * @param string $field
+     * @param mixed  $term
+     * @param array  $options
+     *
+     * @return array
+     */
+    public static function asArray(string $field, $term, array $options = []): array
+    {
+        return [
+            static::KEYWORD => [
+                $field => array_merge(
+                    $options,
+                    [
+                        'value' => $term,
+                    ]
+                ),
+            ],
+        ];
+    }
+}

--- a/tests/Query/Criteria/Search/TermTest.php
+++ b/tests/Query/Criteria/Search/TermTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Elasticsearch\Tests\Query\Criteria\Search;
+
+use Kununu\Elasticsearch\Query\Criteria\Search\Term;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * @group unit
+ */
+class TermTest extends MockeryTestCase
+{
+    protected const TERM = 'what was i looking for?';
+    protected const FIELD = 'field_a';
+
+    public function testSingleField(): void
+    {
+        $this->assertEquals(
+            [
+                'term' => [
+                    self::FIELD => [
+                        'value' => self::TERM,
+                    ],
+                ],
+            ],
+            Term::asArray(self::FIELD, self::TERM)
+        );
+    }
+
+    public function testSingleFieldWithOptions(): void
+    {
+        $this->assertEquals(
+            [
+                'term' => [
+                    self::FIELD => [
+                        'value' => self::TERM,
+                        'boost' => 42,
+                    ],
+                ],
+            ],
+            Term::asArray(self::FIELD, self::TERM, ['boost' => 42])
+        );
+    }
+}


### PR DESCRIPTION
## Problem
Creating `term` queries specifically in the search context of a query (as opposed to filter context) was not very intuitive and required writing boilerplate code.
Example then:
`Query::create()->search(Must::create(Filter::create('field', 'the term')))`

## Solution
Introduce dedicated class `\Kununu\Elasticsearch\Query\Criteria\Search\Term` to support the above use case.
Example now:
`Query::create(Search::create(['field'], 'the term', Search::TERM))`