### PR TITLE
Pass desired source fields to findById

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 ### Deprecated
 
+## [2.4.3](https://github.com/kununu/elasticsearch/compare/v2.4.3...v2.4.2)
+### Backward Compatibility Breaks
+### Bugfixes
+### Added
+### Improvements
+* Allow to pass source fields to return on `Repository::findById` instead of receiving the entire document
+### Deprecated
+
 ## [2.4.2](https://github.com/kununu/elasticsearch/compare/v2.4.1...v2.4.2)
 ### Backward Compatibility Breaks
 ### Bugfixes

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -180,13 +180,17 @@ class Repository implements RepositoryInterface, LoggerAwareInterface
     /**
      * @inheritdoc
      */
-    public function findById(string $id)
+    public function findById(string $id, array $sourceFields = [])
     {
         return $this->executeRead(
-            function () use ($id) {
+            function () use ($id, $sourceFields) {
                 try {
                     $response = $this->client->get(
-                        array_merge($this->buildRequestBase(OperationType::READ), ['id' => $id])
+                        array_merge(
+                            $this->buildRequestBase(OperationType::READ),
+                            ['id' => $id],
+                            empty($sourceFields) ? [] : ['_source' => $sourceFields]
+                        )
                     );
 
                     if (!($response['found'] ?? false)) {

--- a/src/Repository/RepositoryInterface.php
+++ b/src/Repository/RepositoryInterface.php
@@ -48,10 +48,11 @@ interface RepositoryInterface
 
     /**
      * @param string $id
+     * @param array  $sourceFields
      *
      * @return array|\Kununu\Elasticsearch\Repository\PersistableEntityInterface|object
      */
-    public function findById(string $id);
+    public function findById(string $id, array $sourceFields = []);
 
     /**
      * @return int

--- a/tests/Repository/RepositoryTest.php
+++ b/tests/Repository/RepositoryTest.php
@@ -673,6 +673,59 @@ class RepositoryTest extends MockeryTestCase
         $this->assertEquals($endResult, $this->getRepository()->findById(self::ID));
     }
 
+    /**
+     * @dataProvider findByIdResultData
+     *
+     * @param array      $esResult
+     * @param array|null $endResult
+     */
+    public function testFindByIdWithSourceField(array $esResult, $endResult): void
+    {
+        $this->clientMock
+            ->shouldReceive('get')
+            ->once()
+            ->with(
+                [
+                    'index' => self::INDEX['read'],
+                    'type' => self::TYPE,
+                    'id' => self::ID,
+                    '_source' => ['foo', 'foo2']
+                ]
+            )
+            ->andReturn($esResult);
+
+        $this->loggerMock
+            ->shouldNotReceive('error');
+
+        $this->assertEquals($endResult, $this->getRepository()->findById(self::ID, ['foo', 'foo2']));
+    }
+
+    /**
+     * @dataProvider findByIdResultData
+     *
+     * @param array      $esResult
+     * @param array|null $endResult
+     */
+    public function testFindByIdWithEmptySourceField(array $esResult, $endResult): void
+    {
+        $this->clientMock
+            ->shouldReceive('get')
+            ->once()
+            ->with(
+                [
+                    'index' => self::INDEX['read'],
+                    'type' => self::TYPE,
+                    'id' => self::ID,
+                ]
+            )
+            ->andReturn($esResult);
+
+        $this->loggerMock
+            ->shouldNotReceive('error');
+
+        $this->assertEquals($endResult, $this->getRepository()->findById(self::ID, []));
+    }
+
     public function findByIdFails(): void
     {
         $this->clientMock


### PR DESCRIPTION
Allow to pass source fields to return on findById instead of receiving the entire document