### PR TITLE
introduce force_refresh_on_write configuration option for repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,49 @@
 # Changelog
-All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
+
+All notable changes to this project will be documented in this file based on
+the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres
+to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/kununu/elasticsearch/compare/v2.4.2...master)
+
 ### Backward Compatibility Breaks
+
 ### Bugfixes
+
 ### Added
+
 ### Improvements
+
+### Deprecated
+
+## [2.4.4](https://github.com/kununu/elasticsearch/compare/v2.4.4...v2.4.3)
+
+### Backward Compatibility Breaks
+
+### Bugfixes
+
+### Added
+
+* Introduce `force_refresh_on_write` configuration option for repositories. It can be used to force an index refresh
+  after every write operation. This can be very handy for functional and integration tests. But caution! Using this in
+  production environments can severely harm your ES cluster performance.
+
+### Improvements
+
 ### Deprecated
 
 ## [2.4.3](https://github.com/kununu/elasticsearch/compare/v2.4.3...v2.4.2)
+
 ### Backward Compatibility Breaks
+
 ### Bugfixes
+
 ### Added
+
 ### Improvements
+
 * Allow to pass source fields to return on `Repository::findById` instead of receiving the entire document
+
 ### Deprecated
 
 ## [2.4.2](https://github.com/kununu/elasticsearch/compare/v2.4.1...v2.4.2)

--- a/doc/REPOSITORY.md
+++ b/doc/REPOSITORY.md
@@ -85,10 +85,17 @@ Mandatory fields are
  - `type` (string): the name of the Elasticsearch type the `Repository` should connect to
 
 Optional fields are
-- `index` (string): the name of the Elasticsearch index the `Repository` should connect to for for any operation. Useful if you are not using aliases. This **does not** override `index_read` and `index_write` if given.
-- `entity_class` (string): class must implement `PeristableEntityInterface`. If given, the repository will emit entities instead of plain document arrays and accepts object of this class on the `save()` method. 
-- `entity_factory` (object): must be of type `EntityFactoryInterface`. If given, the repository will emit entities instead of plain document arrays.
-- `entity_serializer` (object): must be of type `EntitySerializerInterface`. If given, the repository accepts objects on the `save()` method and serializes them using the given serializer. 
+- `index` (string): the name of the Elasticsearch index the `Repository` should connect to for for any operation. Useful
+  if you are not using aliases. This **does not** override `index_read` and `index_write` if given.
+- `entity_class` (string): class must implement `PeristableEntityInterface`. If given, the repository will emit entities
+  instead of plain document arrays and accepts object of this class on the `save()` method.
+- `entity_factory` (object): must be of type `EntityFactoryInterface`. If given, the repository will emit entities
+  instead of plain document arrays.
+- `entity_serializer` (object): must be of type `EntitySerializerInterface`. If given, the repository accepts objects on
+  the `save()` method and serializes them using the given serializer.
+- `force_refresh_on_write` (bool): If true, the index will be refreshed after every write operation. This can be very
+  handy for functional and integration tests. But caution! Using this in production environments can severely harm your
+  ES cluster performance. Default value is false.
 
 In the future this object might be extended with additional (mandatory) fields.
 

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -318,10 +318,16 @@ class Repository implements RepositoryInterface, LoggerAwareInterface
      */
     protected function buildRequestBase(string $operationType): array
     {
-        return [
+        $base = [
             'index' => $this->config->getIndex($operationType),
             'type' => $this->config->getType(),
         ];
+
+        if ($operationType === OperationType::WRITE && $this->config->getForceRefreshOnWrite()) {
+            $base['refresh'] = true;
+        }
+
+        return $base;
     }
 
     /**

--- a/src/Repository/RepositoryConfiguration.php
+++ b/src/Repository/RepositoryConfiguration.php
@@ -19,6 +19,7 @@ class RepositoryConfiguration
     protected const OPTION_ENTITY_SERIALIZER = 'entity_serializer';
     protected const OPTION_ENTITY_FACTORY = 'entity_factory';
     protected const OPTION_ENTITY_CLASS = 'entity_class';
+    protected const OPTION_FORCE_REFRESH_ON_WRITE = 'force_refresh_on_write';
 
     /**
      * 1 minute per default
@@ -51,6 +52,11 @@ class RepositoryConfiguration
      * @var string
      */
     protected $entityClass;
+
+    /**
+     * @var bool
+     */
+    protected $forceRefreshOnWrite = false;
 
     /**
      * RepositoryConfiguration constructor.
@@ -124,6 +130,11 @@ class RepositoryConfiguration
         return static::DEFAULT_SCROLL_CONTEXT_KEEPALIVE;
     }
 
+    public function getForceRefreshOnWrite(): bool
+    {
+        return $this->forceRefreshOnWrite;
+    }
+
     /**
      * @param array $config
      */
@@ -168,6 +179,10 @@ class RepositoryConfiguration
                     'Invalid entity factory given. Must be of type \Kununu\Elasticsearch\Repository\EntityFactoryInterface'
                 );
             }
+        }
+
+        if (isset($config[static::OPTION_FORCE_REFRESH_ON_WRITE])) {
+            $this->forceRefreshOnWrite = (bool)$config[static::OPTION_FORCE_REFRESH_ON_WRITE];
         }
     }
 

--- a/tests/Repository/RepositoryConfigurationTest.php
+++ b/tests/Repository/RepositoryConfigurationTest.php
@@ -17,7 +17,8 @@ class RepositoryConfigurationTest extends TestCase
     {
         $config = new RepositoryConfiguration([]);
 
-        $this->assertEquals('1m', $config->getScrollContextKeepalive());
+        $this->assertSame('1m', $config->getScrollContextKeepalive());
+        $this->assertFalse($config->getForceRefreshOnWrite());
     }
 
     /**
@@ -79,7 +80,7 @@ class RepositoryConfigurationTest extends TestCase
     public function invalidIndexConfigData(): array
     {
         $cases = [
-            'noting given' => [
+            'nothing given' => [
                 'input' => [],
             ],
             'empty index name given' => [
@@ -131,7 +132,7 @@ class RepositoryConfigurationTest extends TestCase
     public function invalidTypeConfigData(): array
     {
         return [
-            'noting given' => [
+            'nothing given' => [
                 'input' => [],
             ],
             'empty type name given' => [
@@ -249,5 +250,82 @@ class RepositoryConfigurationTest extends TestCase
         );
 
         $config = new RepositoryConfiguration(['entity_class' => '\Foo\Bar']); // NOSONAR
+    }
+
+    /**
+     * @return array
+     */
+    public function forceRefreshOnWriteVariations(): array
+    {
+        return [
+            'param not given' => [
+                'input' => [
+                    'index' => 'foobar',
+                    'type' => '_doc',
+                ],
+                'expected' => false,
+            ],
+            'false given' => [
+                'input' => [
+                    'index' => 'foobar',
+                    'type' => '_doc',
+                    'force_refresh_on_write' => false,
+                ],
+                'expected' => false,
+            ],
+            'falsy value given' => [
+                'input' => [
+                    'index' => 'foobar',
+                    'type' => '_doc',
+                    'force_refresh_on_write' => 0,
+                ],
+                'expected' => false,
+            ],
+            'true given' => [
+                'input' => [
+                    'index' => 'foobar',
+                    'type' => '_doc',
+                    'force_refresh_on_write' => true,
+                ],
+                'expected' => true,
+            ],
+            'true-ish integer given' => [
+                'input' => [
+                    'index' => 'foobar',
+                    'type' => '_doc',
+                    'force_refresh_on_write' => 1,
+                ],
+                'expected' => true,
+            ],
+            'true-ish string given' => [
+                'input' => [
+                    'index' => 'foobar',
+                    'type' => '_doc',
+                    'force_refresh_on_write' => 'yes',
+                ],
+                'expected' => true,
+            ],
+            'not-so-clever-but-still-true-ish string given' => [
+                'input' => [
+                    'index' => 'foobar',
+                    'type' => '_doc',
+                    'force_refresh_on_write' => 'no',
+                ],
+                'expected' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider forceRefreshOnWriteVariations
+     *
+     * @param array $input
+     * @param bool  $expected
+     */
+    public function testForceRefreshOnWrite(array $input, bool $expected): void
+    {
+        $config = new RepositoryConfiguration($input);
+
+        $this->assertSame($expected, $config->getForceRefreshOnWrite());
     }
 }


### PR DESCRIPTION
This introduces a new `force_refresh_on_write` configuration option for repositories.
It can be used to force an index refresh after every write operation.
While this can be very handy for functional and integration tests, be very cautious using it in production environments as it can severely harm your ES cluster performance.