### PR TITLE
add Repository::saveBulk()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
+## [2.4.5](https://github.com/kununu/elasticsearch/compare/v2.4.5...v2.4.4)
+
+### Backward Compatibility Breaks
+
+### Bugfixes
+
+### Added
+
+* `Repository::saveBulk()` was added to support bulk index operations
+
+### Improvements
+
+* Third party dependency upgrades (`phpunit` and `mockery`)
+
+### Deprecated
+
 ## [2.4.4](https://github.com/kununu/elasticsearch/compare/v2.4.4...v2.4.3)
 
 ### Backward Compatibility Breaks
@@ -33,17 +49,11 @@ to [Semantic Versioning](http://semver.org/).
 ### Deprecated
 
 ## [2.4.3](https://github.com/kununu/elasticsearch/compare/v2.4.3...v2.4.2)
-
 ### Backward Compatibility Breaks
-
 ### Bugfixes
-
 ### Added
-
 ### Improvements
-
 * Allow to pass source fields to return on `Repository::findById` instead of receiving the entire document
-
 ### Deprecated
 
 ## [2.4.2](https://github.com/kununu/elasticsearch/compare/v2.4.1...v2.4.2)

--- a/src/Exception/BulkException.php
+++ b/src/Exception/BulkException.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Elasticsearch\Exception;
+
+use Throwable;
+
+/**
+ * Class BulkException
+ *
+ * @package Kununu\Elasticsearch\Exception
+ */
+class BulkException extends WriteOperationException
+{
+    /**
+     * @var array
+     */
+    protected $operations;
+
+    /**
+     * @param string          $message
+     * @param \Throwable|null $previous
+     * @param array|null      $operations
+     */
+    public function __construct($message = "", Throwable $previous = null, ?array $operations = null)
+    {
+        parent::__construct($message, $previous);
+
+        $this->operations = $operations;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOperations(): ?array
+    {
+        return $this->operations;
+    }
+}

--- a/src/Repository/RepositoryInterface.php
+++ b/src/Repository/RepositoryInterface.php
@@ -21,6 +21,11 @@ interface RepositoryInterface
     public function save(string $id, $entity): void;
 
     /**
+     * @param array[]|object[] $entities Associative array with document IDs as keys and documents as values
+     */
+    public function saveBulk(array $entities): void;
+
+    /**
      * @param string $id
      */
     public function delete(string $id): void;

--- a/tests/Repository/RepositoryTest.php
+++ b/tests/Repository/RepositoryTest.php
@@ -5,6 +5,7 @@ namespace Kununu\Elasticsearch\Tests\Repository;
 
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
+use Kununu\Elasticsearch\Exception\BulkException;
 use Kununu\Elasticsearch\Exception\DeleteException;
 use Kununu\Elasticsearch\Exception\DocumentNotFoundException;
 use Kununu\Elasticsearch\Exception\ReadOperationException;
@@ -277,6 +278,212 @@ class RepositoryTest extends MockeryTestCase
             $this->assertEquals(0, $e->getCode());
             $this->assertEquals(self::ID, $e->getDocumentId());
             $this->assertEquals($document, $e->getDocument());
+        }
+    }
+
+    public function testSaveBulkWithArrays(): void
+    {
+        $documents = [
+            'document_id_1' => ['whatever' => 'just some data'],
+            'document_id_2' => ['whatever' => 'just some more data'],
+            'document_id_3' => ['whatever' => 'even more data'],
+            'document_id_4' => ['whatever' => 'what is this even'],
+        ];
+
+        $this->clientMock
+            ->shouldReceive('bulk')
+            ->once()
+            ->with(
+                [
+                    'index' => self::INDEX['write'],
+                    'type' => self::TYPE,
+                    'body' => [
+                        ['index' => ['_id' => 'document_id_1']],
+                        $documents['document_id_1'],
+                        ['index' => ['_id' => 'document_id_2']],
+                        $documents['document_id_2'],
+                        ['index' => ['_id' => 'document_id_3']],
+                        $documents['document_id_3'],
+                        ['index' => ['_id' => 'document_id_4']],
+                        $documents['document_id_4'],
+                    ],
+                ]
+            );
+
+        $this->loggerMock
+            ->shouldNotReceive('error');
+
+        $this->getRepository()->saveBulk($documents);
+    }
+
+    public function testSaveBulkWithForcedRefresh(): void
+    {
+        $documents = [
+            'document_id_1' => ['whatever' => 'just some data'],
+            'document_id_2' => ['whatever' => 'just some more data'],
+            'document_id_3' => ['whatever' => 'even more data'],
+            'document_id_4' => ['whatever' => 'what is this even'],
+        ];
+
+        $this->clientMock
+            ->shouldReceive('bulk')
+            ->once()
+            ->with(
+                [
+                    'index' => self::INDEX['write'],
+                    'type' => self::TYPE,
+                    'body' => [
+                        ['index' => ['_id' => 'document_id_1']],
+                        $documents['document_id_1'],
+                        ['index' => ['_id' => 'document_id_2']],
+                        $documents['document_id_2'],
+                        ['index' => ['_id' => 'document_id_3']],
+                        $documents['document_id_3'],
+                        ['index' => ['_id' => 'document_id_4']],
+                        $documents['document_id_4'],
+                    ],
+                    'refresh' => true,
+                ]
+            );
+
+        $this->loggerMock
+            ->shouldNotReceive('error');
+
+        $this->getRepository(['force_refresh_on_write' => true])->saveBulk($documents);
+    }
+
+    public function testSaveBulkObjectsWithEntitySerializer(): void
+    {
+        $mySerializer = new class implements EntitySerializerInterface {
+            public function toElastic($entity): array
+            {
+                return (array)$entity;
+            }
+        };
+
+        $documents = [];
+        for ($ii = 0; $ii < 3; $ii++) {
+            $document = new stdClass();
+            $document->property_a = 'a' . $ii;
+            $document->property_b = 'b' . $ii;
+            $documents['doc_' . $ii] = $document;
+        }
+
+        $this->clientMock
+            ->shouldReceive('bulk')
+            ->once()
+            ->with(
+                [
+                    'index' => self::INDEX['write'],
+                    'type' => self::TYPE,
+                    'body' => [
+                        ['index' => ['_id' => 'doc_0']],
+                        ['property_a' => 'a0', 'property_b' => 'b0'],
+                        ['index' => ['_id' => 'doc_1']],
+                        ['property_a' => 'a1', 'property_b' => 'b1'],
+                        ['index' => ['_id' => 'doc_2']],
+                        ['property_a' => 'a2', 'property_b' => 'b2'],
+                    ],
+
+                ]
+            );
+
+        $this->loggerMock
+            ->shouldNotReceive('error');
+
+        $this->getRepository(['entity_serializer' => $mySerializer])->saveBulk($documents);
+    }
+
+    public function testSaveBulkObjectsWithEntityClass(): void
+    {
+        $documents = [];
+        for ($ii = 0; $ii < 3; $ii++) {
+            $document = $this->getEntityClass();
+            $document->property_a = 'a' . $ii;
+            $document->property_b = 'b' . $ii;
+            $documents['doc_' . $ii] = $document;
+        }
+
+        $this->clientMock
+            ->shouldReceive('bulk')
+            ->once()
+            ->with(
+                [
+                    'index' => self::INDEX['write'],
+                    'type' => self::TYPE,
+                    'body' => [
+                        ['index' => ['_id' => 'doc_0']],
+                        ['property_a' => 'a0', 'property_b' => 'b0'],
+                        ['index' => ['_id' => 'doc_1']],
+                        ['property_a' => 'a1', 'property_b' => 'b1'],
+                        ['index' => ['_id' => 'doc_2']],
+                        ['property_a' => 'a2', 'property_b' => 'b2'],
+                    ],
+                ]
+            );
+
+        $this->loggerMock
+            ->shouldNotReceive('error');
+
+        $this->getRepository(['entity_class' => get_class($this->getEntityClass())])->saveBulk($documents);
+    }
+
+    public function testSaveBulkObjectsFailsWithoutEntitySerializerAndEntityClass(): void
+    {
+        $this->expectException(RepositoryConfigurationException::class);
+        $this->expectExceptionMessage('No entity serializer configured while trying to persist object');
+
+        $this->getRepository()->saveBulk([self::ID => new stdClass()]);
+    }
+
+    /**
+     * @dataProvider invalidDataTypesForSave
+     *
+     * @param mixed $entity
+     */
+    public function testSaveBulkFailsWithInvalidDataType($entity): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Entity must be of type array or object');
+
+        $this->getRepository()->saveBulk([self::ID => $entity]);
+    }
+
+    public function testSaveBulkArrayFails(): void
+    {
+        $documents = [
+            self::ID => [
+                'foo' => 'bar',
+            ],
+        ];
+
+        $expectedOperations = [
+            ['index' => ['_id' => self::ID]],
+            ['foo' => 'bar'],
+        ];
+
+        $this->clientMock
+            ->shouldReceive('bulk')
+            ->once()
+            ->with(
+                [
+                    'index' => self::INDEX['write'],
+                    'type' => self::TYPE,
+                    'body' => $expectedOperations,
+                ]
+            )
+            ->andThrow(new \Exception(self::ERROR_MESSAGE));
+
+        $this->loggerMock
+            ->shouldReceive('error')
+            ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
+
+        try {
+            $this->getRepository()->saveBulk($documents);
+        } catch (BulkException $e) {
+            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            $this->assertEquals(0, $e->getCode());
+            $this->assertEquals($expectedOperations, $e->getOperations());
         }
     }
 
@@ -1150,6 +1357,62 @@ class RepositoryTest extends MockeryTestCase
             self::ID,
             $document
         );
+    }
+
+    public function testPostSaveBulkIsCalled(): void
+    {
+        $documents = [
+            self::ID => [
+                'whatever' => 'just some data',
+            ],
+        ];
+
+        $this->clientMock
+            ->shouldReceive('bulk')
+            ->once()
+            ->with(
+                [
+                    'index' => self::INDEX['write'],
+                    'type' => self::TYPE,
+                    'body' => [
+                        ['index' => ['_id' => self::ID]],
+                        ['whatever' => 'just some data'],
+                    ],
+                ]
+            );
+
+        $this->loggerMock
+            ->shouldNotReceive('error');
+
+        $manager = new class($this->clientMock, [
+            'index_write' => self::INDEX['write'],
+            'type' => self::TYPE,
+        ], $this) extends Repository {
+            /**
+             * @var \Mockery\Adapter\Phpunit\MockeryTestCase
+             */
+            protected $test;
+
+            public function __construct(Client $client, array $config, MockeryTestCase $test)
+            {
+                parent::__construct($client, $config);
+                $this->test = $test;
+            }
+
+            protected function postSaveBulk(array $entities): void
+            {
+                $this->test->assertEquals(
+                    [
+                        $this->test::ID => [
+                            'whatever' => 'just some data',
+                        ],
+                    ],
+                    $entities
+                );
+            }
+        };
+
+        $manager->saveBulk($documents);
     }
 
     public function testPostDeleteIsCalled(): void


### PR DESCRIPTION
To speed up large indexing tasks, this PR implements a method `saveBulk()` for Repositories which makes use of [Elasticsearch bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/6.4/docs-bulk.html).