### PR TITLE
Retrieve total hits on Elasticsearch Response Repository - Compatible with 6.x and 7.x versions

### DIFF
--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -392,7 +392,7 @@ class Repository implements RepositoryInterface, LoggerAwareInterface
         }
 
         return ResultIterator::create($results)
-            ->setTotal($rawResult['hits']['total'] ?? 0)
+            ->setTotal($rawResult['hits']['total']['value'] ?? 0)
             ->setScrollId($rawResult['_scroll_id'] ?? null);
     }
 

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -391,8 +391,17 @@ class Repository implements RepositoryInterface, LoggerAwareInterface
             );
         }
 
+        /**
+         * This makes it compatible with Elasticsearch 6.x and 7.x.
+         * Versions before 7.x total hits are passed on ['hits']['total'] while on newer versions 7.x
+         * total hits are passed on ['hits']['total']['value']
+         */
+        $total = isset($rawResult['hits']['total']['value']) ?
+            ($rawResult['hits']['total']['value'] ?? 0) :
+            ($rawResult['hits']['total'] ?? 0);
+
         return ResultIterator::create($results)
-            ->setTotal($rawResult['hits']['total']['value'] ?? 0)
+            ->setTotal($total)
             ->setScrollId($rawResult['_scroll_id'] ?? null);
     }
 

--- a/tests/Repository/RepositoryTest.php
+++ b/tests/Repository/RepositoryTest.php
@@ -596,7 +596,9 @@ class RepositoryTest extends MockeryTestCase
             'no results' => [
                 'es_result' => [
                     'hits' => [
-                        'total' => self::DOCUMENT_COUNT,
+                        'total' => [
+                            'value' => self::DOCUMENT_COUNT
+                        ],
                         'hits' => [
 
                         ],
@@ -607,7 +609,9 @@ class RepositoryTest extends MockeryTestCase
             'one result' => [
                 'es_result' => [
                     'hits' => [
-                        'total' => self::DOCUMENT_COUNT,
+                        'total' => [
+                            'value' => self::DOCUMENT_COUNT
+                        ],
                         'hits' => [
                             [
                                 '_index' => self::INDEX['read'],
@@ -632,7 +636,9 @@ class RepositoryTest extends MockeryTestCase
             'two results' => [
                 'es_result' => [
                     'hits' => [
-                        'total' => self::DOCUMENT_COUNT,
+                        'total' => [
+                            'value' => self::DOCUMENT_COUNT
+                        ],
                         'hits' => [
                             [
                                 '_index' => self::INDEX['read'],

--- a/tests/Repository/RepositoryTest.php
+++ b/tests/Repository/RepositoryTest.php
@@ -609,9 +609,8 @@ class RepositoryTest extends MockeryTestCase
             'one result' => [
                 'es_result' => [
                     'hits' => [
-                        'total' => [
-                            'value' => self::DOCUMENT_COUNT
-                        ],
+                        /** Validated Response for Elasticsearch 6.x */
+                        'total' => self::DOCUMENT_COUNT,
                         'hits' => [
                             [
                                 '_index' => self::INDEX['read'],
@@ -636,6 +635,8 @@ class RepositoryTest extends MockeryTestCase
             'two results' => [
                 'es_result' => [
                     'hits' => [
+                        /** Validated Response for Elasticsearch 7.x */
+                        /** https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response */
                         'total' => [
                             'value' => self::DOCUMENT_COUNT
                         ],


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response

The goal of this pull request is to **turn compatible** to retrieve of total documents from the Elasticsearch response between `6.x` and `7.x` Elasticsearch versions.

No breaking change is applied.