### PR TITLE
Bug fixes

### DIFF
--- a/src/Exception/UpdateException.php
+++ b/src/Exception/UpdateException.php
@@ -8,7 +8,7 @@ use Throwable;
 class UpdateException extends WriteOperationException
 {
     protected mixed $documentId;
-    protected array $document;
+    protected ?array $document;
 
     public function __construct(
         string $message = "",

--- a/src/Exception/UpsertException.php
+++ b/src/Exception/UpsertException.php
@@ -8,7 +8,7 @@ use Throwable;
 class UpsertException extends WriteOperationException
 {
     protected mixed $documentId;
-    protected array $document;
+    protected ?array $document;
 
     public function __construct(
         string $message = "",

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -164,7 +164,7 @@ class Repository implements RepositoryInterface, LoggerAwareInterface
         );
     }
 
-    public function findById(string $id, array $sourceFields = []): PersistableEntityInterface|array|null
+    public function findById(string $id, array $sourceFields = []): object|array|null
     {
         return $this->executeRead(
             function () use ($id, $sourceFields) {

--- a/src/Repository/RepositoryInterface.php
+++ b/src/Repository/RepositoryInterface.php
@@ -63,7 +63,7 @@ interface RepositoryInterface
     /**
      * This method retrieves a single document based on a given $id.
      */
-    public function findById(string $id, array $sourceFields = []): PersistableEntityInterface|array|null;
+    public function findById(string $id, array $sourceFields = []): object|array|null;
 
     /**
      * This method returns the total document count in an index.


### PR DESCRIPTION
- Include null as an acceptable value to the document attribute of UpsertException and UpdateException
- Replace PersistableEntityInterface by object in findById method

Note: the PersistableEntityInterface forces the implementation of fromElasticDocument and toElastic methods. But the method findById allows the entity's creation by a factory, and in this case, there is no need for the implementation of the aforementioned methods. Another option could be the creation of a marker Interface.