### PR TITLE
PHP 8 support with Elasticsearch 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,32 @@ All notable changes to this project will be documented in this file based on
 the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres
 to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/kununu/elasticsearch/compare/v2.4.6...master)
+## [Unreleased](https://github.com/kununu/elasticsearch/compare/v2.6.0...master)
 
 ### Backward Compatibility Breaks
 
 ### Bugfixes
 
 ### Added
+
+### Improvements
+
+### Deprecated
+
+## [2.6.0](https://github.com/kununu/elasticsearch/compare/v2.5.4...v2.6.0)
+
+### Backward Compatibility Breaks
+
+* Changed class names of full-text queries (e.g. `Match` to `MatchQuery`). This is due to `"match"`becoming a reserved keyword in PHP 8
+
+### Bugfixes
+
+### Added
+
+* Bring back support for PHP 8
+* Use kununu elasticsearch 6.5.1 client fork (`kununu/elasticsearch-client`) with PHP 8 support
+* This should be **only used as a transitional version** for applications that need to be on PHP 8 but are still using Elasticsearch 6 servers
+  * Those applications should upgrade to use Elasticsearch 7 servers and converted to use 4.x releases of this library
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This package contains two implementations of the `QueryInterface`:
  - [RawQuery](doc/RAWQUERY.md)
 
 ### IndexManager
-This package provides easy access to a a few commonly used Elasticsearch index management features like creating indices and managing aliases.
+This package provides easy access to a few commonly used Elasticsearch index management features like creating indices and managing aliases.
 
 [More explanation and examples](doc/INDEX_MANAGER.md)
 

--- a/composer.json
+++ b/composer.json
@@ -4,18 +4,25 @@
     "type": "library",
     "license": "proprietary",
     "minimum-stability": "stable",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/kununu/elasticsearch-client.git",
+            "no-api": true
+        }
+    ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "elasticsearch/elasticsearch": "~6.5.0",
+        "kununu/elasticsearch-client": "~6.5.1",
         "psr/log": "~1.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.4",
-        "phpunit/phpunit": "^8.3"
+        "phpunit/phpunit": "^8.5 || ^9.5"
     },
     "config": {
         "preferred-install": {

--- a/src/Query/Criteria/Search.php
+++ b/src/Query/Criteria/Search.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Kununu\Elasticsearch\Query\Criteria;
 
 use InvalidArgumentException;
-use Kununu\Elasticsearch\Query\Criteria\Search\Match;
+use Kununu\Elasticsearch\Query\Criteria\Search\MatchQuery;
 use Kununu\Elasticsearch\Query\Criteria\Search\MatchPhrase;
 use Kununu\Elasticsearch\Query\Criteria\Search\MatchPhrasePrefix;
 use Kununu\Elasticsearch\Query\Criteria\Search\QueryString;
@@ -22,7 +22,7 @@ class Search implements SearchInterface
 {
     use ConstantContainerTrait;
 
-    public const MATCH = Match::KEYWORD;
+    public const MATCH = MatchQuery::KEYWORD;
     public const MATCH_PHRASE = MatchPhrase::KEYWORD;
     public const MATCH_PHRASE_PREFIX = MatchPhrasePrefix::KEYWORD;
     public const QUERY_STRING = QueryString::KEYWORD;
@@ -109,7 +109,7 @@ class Search implements SearchInterface
                 $query = QueryString::asArray($this->fields, $this->queryString, $this->options);
                 break;
             case static::MATCH:
-                $query = Match::asArray($this->fields, $this->queryString, $this->options);
+                $query = MatchQuery::asArray($this->fields, $this->queryString, $this->options);
                 break;
             case static::MATCH_PHRASE:
                 $query = MatchPhrase::asArray($this->fields, $this->queryString, $this->options);

--- a/src/Query/Criteria/Search/MatchQuery.php
+++ b/src/Query/Criteria/Search/MatchQuery.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 namespace Kununu\Elasticsearch\Query\Criteria\Search;
 
 /**
- * Class Match
+ * Class MatchQuery
  *
  * @package Kununu\Elasticsearch\Query\Criteria\Search
  */
-class Match
+class MatchQuery
 {
     use MultiFieldTrait;
 

--- a/tests/Query/Criteria/Search/MatchQueryTest.php
+++ b/tests/Query/Criteria/Search/MatchQueryTest.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace Kununu\Elasticsearch\Tests\Query\Criteria\Search;
 
-use Kununu\Elasticsearch\Query\Criteria\Search\Match;
+use Kununu\Elasticsearch\Query\Criteria\Search\MatchQuery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * @group unit
  */
-class MatchTest extends MockeryTestCase
+class MatchQueryTest extends MockeryTestCase
 {
     protected const QUERY_STRING = 'what was i looking for?';
 
@@ -23,7 +23,7 @@ class MatchTest extends MockeryTestCase
                     ],
                 ],
             ],
-            Match::asArray(['field_a'], self::QUERY_STRING)
+            MatchQuery::asArray(['field_a'], self::QUERY_STRING)
         );
     }
 
@@ -36,7 +36,7 @@ class MatchTest extends MockeryTestCase
                     'query' => self::QUERY_STRING,
                 ],
             ],
-            Match::asArray(['field_a', 'field_b'], self::QUERY_STRING)
+            MatchQuery::asArray(['field_a', 'field_b'], self::QUERY_STRING)
         );
     }
 
@@ -51,7 +51,7 @@ class MatchTest extends MockeryTestCase
                     ],
                 ],
             ],
-            Match::asArray(['field_a'], self::QUERY_STRING, ['boost' => 42])
+            MatchQuery::asArray(['field_a'], self::QUERY_STRING, ['boost' => 42])
         );
     }
 
@@ -65,7 +65,7 @@ class MatchTest extends MockeryTestCase
                     'boost' => 42,
                 ],
             ],
-            Match::asArray(['field_a', 'field_b'], self::QUERY_STRING, ['boost' => 42])
+            MatchQuery::asArray(['field_a', 'field_b'], self::QUERY_STRING, ['boost' => 42])
         );
     }
 }


### PR DESCRIPTION
- Bring back support for PHP 8
- Use kununu elasticsearch 6.5.1 client fork (`kununu/elasticsearch-client`) with PHP 8 support
- Changed class names of full-text queries (e.g. `Match` to `MatchQuery`). This is due to `"match"`becoming a reserved keyword in PHP 8