### PR TITLE
Send scroll_id in the body of the request in Repository::findByScrollId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file based on
 the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres
 to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/kununu/elasticsearch/compare/v6.0.0...master)
+## [Unreleased](https://github.com/kununu/elasticsearch/compare/v6.0.1...master)
 
 ### Backward Compatibility Breaks
 
@@ -13,6 +13,20 @@ to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Improvements
+
+### Deprecated
+
+## [6.0.1](https://github.com/kununu/elasticsearch/compare/v6.0.1...v6.0.0)
+
+### Backward Compatibility Breaks
+
+### Bugfixes
+
+### Added
+
+### Improvements
+
+* Send `scroll_id` in the body of the request in `Repository::findByScrollId` to get rid of deprecation notices
 
 ### Deprecated
 

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -162,7 +162,9 @@ class Repository implements RepositoryInterface, LoggerAwareInterface
         return $this->executeRead(
             fn() => $this->parseRawSearchResponse(
                 $this->client->scroll([
-                    'scroll_id' => $scrollId,
+                    'body' => [
+                        'scroll_id' => $scrollId,
+                    ],
                     'scroll'    => $scrollContextKeepalive ?: $this->config->getScrollContextKeepalive(),
                 ])
             )

--- a/tests/Repository/RepositoryFindByScrollIdTest.php
+++ b/tests/Repository/RepositoryFindByScrollIdTest.php
@@ -18,8 +18,10 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
             ->expects($this->once())
             ->method('scroll')
             ->with([
-                'scroll_id' => $scrollId,
-                'scroll'    => RepositoryConfiguration::DEFAULT_SCROLL_CONTEXT_KEEPALIVE,
+                'body'   => [
+                    'scroll_id' => $scrollId,
+                ],
+                'scroll' => RepositoryConfiguration::DEFAULT_SCROLL_CONTEXT_KEEPALIVE,
             ])
             ->willReturn($esResult);
 
@@ -42,8 +44,10 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
             ->expects($this->once())
             ->method('scroll')
             ->with([
-                'scroll_id' => $scrollId,
-                'scroll'    => $keepalive,
+                'body'   => [
+                    'scroll_id' => $scrollId,
+                ],
+                'scroll' => $keepalive,
             ])
             ->willReturn($esResult);
 
@@ -65,8 +69,10 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
             ->expects($this->once())
             ->method('scroll')
             ->with([
-                'scroll_id' => $scrollId,
-                'scroll'    => RepositoryConfiguration::DEFAULT_SCROLL_CONTEXT_KEEPALIVE,
+                'body'   => [
+                    'scroll_id' => $scrollId,
+                ],
+                'scroll' => RepositoryConfiguration::DEFAULT_SCROLL_CONTEXT_KEEPALIVE,
             ])
             ->willReturn(array_merge($esResult, ['_scroll_id' => $scrollId]));
 
@@ -96,8 +102,10 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
             ->expects($this->once())
             ->method('scroll')
             ->with([
-                'scroll_id' => $scrollId,
-                'scroll'    => RepositoryConfiguration::DEFAULT_SCROLL_CONTEXT_KEEPALIVE,
+                'body'   => [
+                    'scroll_id' => $scrollId,
+                ],
+                'scroll' => RepositoryConfiguration::DEFAULT_SCROLL_CONTEXT_KEEPALIVE,
             ])
             ->willReturn(array_merge($esResult, ['_scroll_id' => $scrollId]));
 
@@ -128,7 +136,9 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
             ->expects($this->once())
             ->method('scroll')
             ->with([
-                'scroll_id' => $scrollId,
+                'body' => [
+                    'scroll_id' => $scrollId,
+                ],
                 'scroll'    => RepositoryConfiguration::DEFAULT_SCROLL_CONTEXT_KEEPALIVE,
             ])
             ->willThrowException(new Exception(self::ERROR_MESSAGE));


### PR DESCRIPTION
- Send `scroll_id` in the body of the request in `Repository::findByScrollId` to get rid of deprecation notices