### PR TITLE
KUNENABLE-161 Add support for Symfony 6.4 to kununu/elasticsearch-bundle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
     # Disable automatic rebasing to prevent overloading our CICD system
     rebase-strategy: "disabled"
     versioning-strategy: auto
-    # By default Dependabot has a limit of the number of open PR for version updates
+    # By default, Dependabot has a limit of the number of open PR for version updates
     # and security updates.
     # See other defaults in here: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload coverage files
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.job }}-${{ matrix.php-version }}-coverage
+          name: ${{ github.job }}-${{ matrix.php-version }}-${{ matrix.dependencies }}-coverage
           path: tests/.results/
 
   sonarcloud:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,81 +1,78 @@
 name: Continuous Integration
 
 on:
-    push:
-        branches:
-            - master
-            - 6.0
-            - 5.0
-            - 4.0
-            - 3.0
-            - 2.5
-    pull_request:
-        types: [ opened, synchronize, reopened ]
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [ opened, synchronize, reopened ]
 
 env:
-    fail-fast: true
+  fail-fast: true
 
 jobs:
-    build:
-        name: PHPUnit
-        runs-on: ubuntu-20.04
-        strategy:
-            matrix:
-                php-version:
-                    - 8.0
-                dependencies:
-                    - lowest
-                    - highest
+  build:
+    name: PHPUnit
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        php-version:
+          - 8.1
+          - 8.2
+          - 8.3
+        dependencies:
+          - lowest
+          - highest
 
-        steps:
-            -   name: Checkout
-                uses: actions/checkout@v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php-version }}
-                    coverage: xdebug
-                    extensions: ${{ matrix.extensions }}
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v4
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: xdebug
+          extensions: ${{ matrix.extensions }}
 
-            -   name: Install Composer Dependencies
-                uses: ramsey/composer-install@v1
-                with:
-                    dependency-versions: ${{ matrix.dependencies }}
-                    composer-options: "--prefer-stable"
+      - name: Install Composer Dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          dependency-versions: ${{ matrix.dependencies }}
+          composer-options: "--prefer-stable"
 
-            -   name: Run PHPUnit
-                run: vendor/bin/phpunit
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit
 
-            -   name: Upload coverage files
-                uses: actions/upload-artifact@v2
-                with:
-                    name: ${{ github.job }}-${{ matrix.php-version }}-coverage
-                    path: tests/.results/
+      - name: Upload coverage files
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-${{ matrix.php-version }}-coverage
+          path: tests/.results/
 
-    sonarcloud:
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
-            -   uses: actions/checkout@v2
-                with:
-                    # Disabling shallow clone is recommended for improving relevancy of reporting
-                    fetch-depth: 0
+  sonarcloud:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
 
-            -   uses: actions/download-artifact@v2
-                with:
-                    name: build-8-coverage
-                    path: tests/.results/
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-8.1-highest-coverage
+          path: tests/.results/
 
-            -   name: Fix Code Coverage Paths
-                working-directory: tests/.results/
-                run: |
-                    sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' tests-clover.xml
-                    sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' tests-junit.xml
+      - name: Fix Code Coverage Paths
+        working-directory: tests/.results/
+        run: |
+          sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' tests-clover.xml
+          sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' tests-junit.xml
 
-            -   name: SonarCloud Scan
-                uses: sonarsource/sonarcloud-github-action@master
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - master
+      - '6.0'
+      - '5.0'
+      - '4.0'
+      - '3.0'
+      - '2.5'
+
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v4
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           coverage: xdebug

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ deploy.prop
 log/
 .env
 .env.test
-.phpunit.result.cache
+.phpunit.cache
+.phpunit.result
 tests/.results
 composer.lock
 .php-cs-fixer.cache
+phpunit.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,26 @@ to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
+## [7.0.0](https://github.com/kununu/elasticsearch/compare/v7.0.0...v6.0.1)
+
+### Backward Compatibility Breaks
+
+* Drop support for PHP 8.0 - PHP 8.1 is now the minimum version.
+
+### Bugfixes
+
+### Added
+
+### Improvements
+
+* Upgraded PHPUnit to version 10.5
+* Refactor some code to take advantage of PHP 8.1 features (read-only properties)
+* Fix tests that used deprecated/removed features on PHPUnit 10.5
+* Refactor tests to be more PHPUnit 10.5 compliant (e.g. using attributes for data providers, make all data providers static, etc.) 
+* Updated versions of continuous integration components
+
+### Deprecated
+
 ## [6.0.1](https://github.com/kununu/elasticsearch/compare/v6.0.1...v6.0.0)
 
 ### Backward Compatibility Breaks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 Contributions are more than **welcome** and will be fully **credited**.
 
-We accept contributions via Pull Requests on [Github](https://github.com/kununu/elasticsearch).
+We accept contributions via Pull Requests on [GitHub](https://github.com/kununu/elasticsearch).
 
 ## Pull Requests
 
-- **[PSR-12 Coding Standard](https://www.php-fig.org/psr/psr-12/)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+- **[kununu Coding Standards](https://github.com/kununu/kununu-scripts)** - The kununu coding standards are an extension of the [PSR-12](https://www.php-fig.org/psr/psr-12/). Check out [kununu Coding Standards](https://github.com/kununu/kununu-scripts) for more details. In development mode the package [kununu-scripts](https://github.com/kununu/kununu-scripts) is already a dependency that expose commands that you can use to meet our standards.
 
-- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it doesn't have tests.
+- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it does not have tests.
 
 - **Document any change in behaviour** - Make sure the [CHANGELOG.md](CHANGELOG.md), [README.md](README.md) and any other relevant documentation are kept up-to-date.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,26 @@
 # kununu/elasticsearch
 
 ## Purpose
+
 This package aims to
  1. reduce cognitive load when interacting with Elasticsearch by providing an intuitive query language with a fluent interface while staying very close to Elasticsearch terminology
  2. make your project independent of the underlying client library
 
 ## Quickstart
 It does not take a lot to get you up and running with Elasticsearch. All that's required is a `Repository` which can be used to execute requests (e.g. to save a document, query for documents, etc.)
+
 ```php
+<?php
+declare(strict_types=1);
+
+use Elasticsearch\ClientBuilder;
+use Kununu\Elasticsearch\Query\Criteria\Filter;
+use Kununu\Elasticsearch\Query\Criteria\Search;
+use Kununu\Elasticsearch\Query\Query;
+use Kununu\Elasticsearch\Repository\Repository;
+
 // create very minimal client
-$client = \Elasticsearch\ClientBuilder::create()->build();
+$client = ClientBuilder::create()->build();
 
 // create a new repository and bind it to my_index/my_type
 $repository = new Repository(
@@ -43,6 +54,7 @@ $repository->delete('the_document_id');
 ```
 
 ## Technical Concept
+
 The key features of this package are:
  - Repositories
  - Queries
@@ -50,9 +62,9 @@ The key features of this package are:
 
 ### Repositories
 
-Very similar
-to [Entity Repositories in Doctrine](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/working-with-objects.html)
-, a `Repository` in this package is a class which capsules Elasticsearch specific logic - for a specific index.
+Very similar to [Entity Repositories in Doctrine](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/working-with-objects.html), a `Repository` in this package is a class which encapsulates
+Elasticsearch specific logic - for a specific index.
+
 Repositories execute queries against the index (and type) they are bound to.
 
 [More explanation and examples](doc/REPOSITORY.md)
@@ -73,7 +85,7 @@ This package contains two implementations of the `QueryInterface`:
 
 ### IndexManager
 
-This package provides easy access to a a few commonly used Elasticsearch index management features like creating indices
+This package provides easy access to a few commonly used Elasticsearch index management features like creating indices
 and managing aliases.
 
 [More explanation and examples](doc/INDEX_MANAGER.md)
@@ -90,6 +102,7 @@ library. Any other version may or may not work.
 | 4.x                    | 7.x                               | 7.9           | \>=8.0       |
 | 5.x                    | 7.x                               | 7.9           | \>=8.0       |
 | 6.x                    | 7.x                               | 7.9           | \>=8.0       |
+| 7.x                    | 7.x                               | 7.9           | \>=8.1       |
 
 See also https://github.com/elastic/elasticsearch-php#version-matrix
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,20 +1,24 @@
 # Security Policy
 
+## For external contributors
 
-## Reporting a Vulnerability
+If you want to report any security vulnerabilities please do so by creating an [issue](https://github.com/kununu/elasticsearch/issues).
+Additionally, if you have a fix then please create a pull request and link it to the issue you have created.
+
+## For kununu developers
+
+### Reporting a Vulnerability
 
 Jira is our entrypoint to report security vulnerabilities. Having this mind a KUNSECU user story (type Vulnerability) needs to be created.
 
-### How to fill the user story?
+#### How to fill the user story?
 
-Follow this [documentation](https://confluence.xing.hh/pages/viewpage.action?pageId=381133070).
+Follow this [documentation](https://new-work.atlassian.net/wiki/spaces/kununu/pages/47846323/Vulnerability+Issue+Type+Jira).
 
+#### To which team do I assign the user story?
 
-### To which team do I assign the user story?
-
-Follow the [component ownership matrix](https://confluence.xing.hh/display/kununu/Component+ownership+and+support) and assign it to the corresponding team.
-
+Follow the [domain ownership matrix](https://new-work.atlassian.net/wiki/spaces/kununu/pages/113148000/Domain+ownership+matrix) and assign it to the corresponding team.
 
 ## Reporting the update of dependencies
 
-This is the benefit of having Dependabot. It will open pull requests for security and version updates. For more information check the Github [documentation](https://docs.github.com/en/github/administering-a-repository/managing-pull-requests-for-dependency-updates).
+This is the benefit of having Dependabot. It will open pull requests for security and version updates. For more information check the GitHub [documentation](https://docs.github.com/en/github/administering-a-repository/managing-pull-requests-for-dependency-updates).

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "ext-iconv": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "elasticsearch/elasticsearch": "^7.0.0",
+    "elasticsearch/elasticsearch": "^7.0",
     "psr/log": "^1.0|^2.0|^3.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,17 +5,17 @@
   "license": "proprietary",
   "minimum-stability": "stable",
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.1",
     "ext-ctype": "*",
     "ext-iconv": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
     "elasticsearch/elasticsearch": "^7.0.0",
-    "psr/log": "~1.0"
+    "psr/log": "^1.0|^2.0|^3.0"
   },
   "require-dev": {
-    "kununu/scripts": ">=4.0",
-    "phpunit/phpunit": "^9.6"
+    "kununu/scripts": ">=5.0",
+    "phpunit/phpunit": "^10.5"
   },
   "autoload": {
     "psr-4": {
@@ -28,8 +28,8 @@
     }
   },
   "scripts": {
-    "test": "phpunit --no-coverage tests",
-    "test-coverage": "XDEBUG_MODE=coverage phpunit --coverage-clover tests/.results/coverage.xml --coverage-html tests/.results/html/ tests"
+    "test": "phpunit --log-events-text phpunit.log --no-coverage --no-logging --no-progress --testsuite Full",
+    "test-coverage": "XDEBUG_MODE=coverage phpunit --log-events-text phpunit.log --no-progress --testsuite Full"
   },
   "scripts-descriptions": {
     "test": "Run all tests",
@@ -38,9 +38,6 @@
   "config": {
     "allow-plugins": {
       "kununu/scripts": true
-    },
-    "preferred-install": {
-      "*": "dist"
     },
     "sort-packages": true
   }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://phpunit.readthedocs.io/en/9.6/ -->
+<!-- https://phpunit.readthedocs.io/en/10.5/ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd" bootstrap="vendor/autoload.php"
-         colors="true" beStrictAboutChangesToGlobalState="true" testdox="true">
-  <coverage includeUncoveredFiles="true">
-    <include>
-      <directory>src</directory>
-    </include>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php"
+         colors="true" beStrictAboutChangesToGlobalState="true" cacheDirectory=".phpunit.cache" testdox="true">
+  <coverage>
     <report>
       <clover outputFile="tests/.results/tests-clover.xml"/>
       <html outputDirectory="tests/.results/html/"/>
@@ -17,11 +14,16 @@
     <ini name="display_errors" value="true"/>
   </php>
   <testsuites>
-    <testsuite name="Elasticsearch Test Suite">
+    <testsuite name="Full">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
   <logging>
     <junit outputFile="tests/.results/tests-junit.xml"/>
   </logging>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Exception/BulkException.php
+++ b/src/Exception/BulkException.php
@@ -7,8 +7,11 @@ use Throwable;
 
 class BulkException extends WriteOperationException
 {
-    public function __construct(string $message = '', ?Throwable $previous = null, protected ?array $operations = null)
-    {
+    public function __construct(
+        string $message = '',
+        ?Throwable $previous = null,
+        protected readonly ?array $operations = null
+    ) {
         parent::__construct($message, $previous);
     }
 

--- a/src/Exception/DeleteException.php
+++ b/src/Exception/DeleteException.php
@@ -7,8 +7,11 @@ use Throwable;
 
 class DeleteException extends RepositoryException
 {
-    public function __construct(string $message = '', ?Throwable $previous = null, protected mixed $documentId = null)
-    {
+    public function __construct(
+        string $message = '',
+        ?Throwable $previous = null,
+        protected readonly mixed $documentId = null
+    ) {
         parent::__construct($message, $previous);
     }
 

--- a/src/Exception/ReadOperationException.php
+++ b/src/Exception/ReadOperationException.php
@@ -7,8 +7,11 @@ use Throwable;
 
 class ReadOperationException extends RepositoryException
 {
-    public function __construct(string $message = '', ?Throwable $previous = null, protected mixed $query = null)
-    {
+    public function __construct(
+        string $message = '',
+        ?Throwable $previous = null,
+        protected readonly mixed $query = null
+    ) {
         parent::__construct($message, $previous);
     }
 

--- a/src/Exception/UpdateException.php
+++ b/src/Exception/UpdateException.php
@@ -10,8 +10,8 @@ class UpdateException extends WriteOperationException
     public function __construct(
         string $message = '',
         ?Throwable $previous = null,
-        protected mixed $documentId = null,
-        protected ?array $document = null
+        protected readonly mixed $documentId = null,
+        protected readonly ?array $document = null
     ) {
         parent::__construct($message, $previous);
     }

--- a/src/Exception/UpsertException.php
+++ b/src/Exception/UpsertException.php
@@ -10,8 +10,8 @@ class UpsertException extends WriteOperationException
     public function __construct(
         string $message = '',
         ?Throwable $previous = null,
-        protected mixed $documentId = null,
-        protected ?array $document = null
+        protected readonly mixed $documentId = null,
+        protected readonly ?array $document = null
     ) {
         parent::__construct($message, $previous);
     }

--- a/src/IndexManagement/IndexManager.php
+++ b/src/IndexManagement/IndexManager.php
@@ -18,7 +18,7 @@ class IndexManager implements IndexManagerInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
-    public function __construct(protected Client $client)
+    public function __construct(protected readonly Client $client)
     {
     }
 

--- a/src/Query/Aggregation.php
+++ b/src/Query/Aggregation.php
@@ -15,24 +15,21 @@ class Aggregation implements AggregationInterface
      */
     public const GLOBAL = 'global';
 
+    protected readonly string $name;
     /** @var AggregationInterface[] */
     protected array $nestedAggregations = [];
 
     public function __construct(
-        protected ?string $field,
-        protected string $type,
-        protected string $name = '',
-        protected array $options = []
+        protected readonly ?string $field,
+        protected readonly string $type,
+        string $name = '',
+        protected readonly array $options = []
     ) {
         if (!Metric::hasConstant($type) && !Bucket::hasConstant($type) && $type !== static::GLOBAL) {
             throw new InvalidArgumentException('Unknown type "' . $type . '" given');
         }
 
-        if (empty($name)) {
-            $name = spl_object_hash($this);
-        }
-
-        $this->name = $name;
+        $this->name = empty($name) ? spl_object_hash($this) : $name;
     }
 
     public static function create(string $field, string $type, string $name = '', array $options = []): Aggregation

--- a/src/Query/Criteria/Filter.php
+++ b/src/Query/Criteria/Filter.php
@@ -17,10 +17,10 @@ use LogicException;
 class Filter implements FilterInterface
 {
     public function __construct(
-        protected string $field,
-        protected mixed $value,
-        protected ?string $operator = null,
-        protected array $options = []
+        protected readonly string $field,
+        protected readonly mixed $value,
+        protected readonly ?string $operator = null,
+        protected readonly array $options = []
     ) {
         if ($operator !== null && !Operator::hasConstant($operator)) {
             throw new InvalidArgumentException('Unknown operator "' . $operator . '" given');

--- a/src/Query/Criteria/Search.php
+++ b/src/Query/Criteria/Search.php
@@ -25,10 +25,10 @@ class Search implements SearchInterface
     public const TERM = TermQuery::KEYWORD;
 
     public function __construct(
-        protected array $fields,
-        protected string $queryString,
-        protected string $type = self::QUERY_STRING,
-        protected array $options = []
+        protected readonly array $fields,
+        protected readonly string $queryString,
+        protected readonly string $type = self::QUERY_STRING,
+        protected readonly array $options = []
     ) {
         if (empty($fields)) {
             throw new InvalidArgumentException('No fields given');

--- a/src/Query/RawQuery.php
+++ b/src/Query/RawQuery.php
@@ -5,7 +5,7 @@ namespace Kununu\Elasticsearch\Query;
 
 class RawQuery extends AbstractQuery
 {
-    public function __construct(protected array $body = [])
+    public function __construct(protected readonly array $body = [])
     {
     }
 

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -30,9 +30,9 @@ class Repository implements RepositoryInterface, LoggerAwareInterface
 
     protected const EXCEPTION_PREFIX = 'Elasticsearch exception: ';
 
-    protected RepositoryConfiguration $config;
+    protected readonly RepositoryConfiguration $config;
 
-    public function __construct(protected Client $client, array $config)
+    public function __construct(protected readonly Client $client, array $config)
     {
         $this->config = new RepositoryConfiguration($config);
     }
@@ -141,7 +141,7 @@ class Repository implements RepositoryInterface, LoggerAwareInterface
 
     public function findScrollableByQuery(
         QueryInterface $query,
-        string|null $scrollContextKeepalive = null
+        ?string $scrollContextKeepalive = null
     ): ResultIteratorInterface {
         return $this->executeRead(
             function() use ($query, $scrollContextKeepalive) {
@@ -157,7 +157,7 @@ class Repository implements RepositoryInterface, LoggerAwareInterface
 
     public function findByScrollId(
         string $scrollId,
-        string|null $scrollContextKeepalive = null
+        ?string $scrollContextKeepalive = null
     ): ResultIteratorInterface {
         return $this->executeRead(
             fn() => $this->parseRawSearchResponse(

--- a/src/Result/AggregationResult.php
+++ b/src/Result/AggregationResult.php
@@ -5,7 +5,7 @@ namespace Kununu\Elasticsearch\Result;
 
 class AggregationResult implements AggregationResultInterface
 {
-    public function __construct(protected string $name, protected array $fields = [])
+    public function __construct(protected readonly string $name, protected readonly array $fields = [])
     {
     }
 

--- a/tests/IndexManagement/IndexManagerTest.php
+++ b/tests/IndexManagement/IndexManagerTest.php
@@ -12,6 +12,7 @@ use Kununu\Elasticsearch\Exception\MoreThanOneIndexForAliasException;
 use Kununu\Elasticsearch\Exception\NoIndexForAliasException;
 use Kununu\Elasticsearch\IndexManagement\IndexManager;
 use Kununu\Elasticsearch\IndexManagement\IndexManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -19,25 +20,25 @@ use stdClass;
 
 final class IndexManagerTest extends TestCase
 {
-    protected const INDEX = 'my_index';
-    protected const ALIAS = 'my_alias';
-    protected const MAPPING = [
+    private const INDEX = 'my_index';
+    private const ALIAS = 'my_alias';
+    private const MAPPING = [
         'properties' => [
             'field_a' => ['type' => 'text'],
         ],
     ];
 
-    protected Client|MockObject $clientMock;
-    protected IndicesNamespace|MockObject $indicesMock;
-    protected LoggerInterface|MockObject $loggerMock;
+    private MockObject&Client $clientMock;
+    private MockObject&IndicesNamespace $indicesMock;
+    private MockObject&LoggerInterface $loggerMock;
 
     public static function notAcknowledgedResponseDataProvider(): array
     {
         return [
-            'acknowledged false'         => [
+            'acknowledged_false'         => [
                 'response' => ['acknowledged' => false],
             ],
-            'acknowledged field missing' => [
+            'acknowledged_field_missing' => [
                 'response' => [],
             ],
         ];
@@ -48,7 +49,7 @@ final class IndexManagerTest extends TestCase
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('putAlias')
             ->with(
                 [
@@ -59,7 +60,7 @@ final class IndexManagerTest extends TestCase
             ->willReturn(['acknowledged' => true]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getManager()->addAlias(
@@ -68,13 +69,13 @@ final class IndexManagerTest extends TestCase
         );
     }
 
-    /** @dataProvider notAcknowledgedResponseDataProvider */
+    #[DataProvider('notAcknowledgedResponseDataProvider')]
     public function testAddAliasFails(array $response): void
     {
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('putAlias')
             ->with(
                 [
@@ -85,7 +86,7 @@ final class IndexManagerTest extends TestCase
             ->willReturn($response);
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 'Elasticsearch exception: Could not add alias for index',
@@ -106,7 +107,7 @@ final class IndexManagerTest extends TestCase
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteAlias')
             ->with(
                 [
@@ -117,7 +118,7 @@ final class IndexManagerTest extends TestCase
             ->willReturn(['acknowledged' => true]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getManager()->removeAlias(
@@ -126,13 +127,13 @@ final class IndexManagerTest extends TestCase
         );
     }
 
-    /** @dataProvider notAcknowledgedResponseDataProvider */
+    #[DataProvider('notAcknowledgedResponseDataProvider')]
     public function testRemoveAliasFails(array $response): void
     {
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteAlias')
             ->with(
                 [
@@ -143,7 +144,7 @@ final class IndexManagerTest extends TestCase
             ->willReturn($response);
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 'Elasticsearch exception: Could not remove alias for index',
@@ -167,7 +168,7 @@ final class IndexManagerTest extends TestCase
         $toIndex = 'to_ ' . self::INDEX;
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateAliases')
             ->with(
                 [
@@ -182,7 +183,7 @@ final class IndexManagerTest extends TestCase
             ->willReturn(['acknowledged' => true]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getManager()->switchAlias(
@@ -192,7 +193,7 @@ final class IndexManagerTest extends TestCase
         );
     }
 
-    /** @dataProvider notAcknowledgedResponseDataProvider */
+    #[DataProvider('notAcknowledgedResponseDataProvider')]
     public function testSwitchAliasFails(array $response): void
     {
         $this->setUpIndexOperation();
@@ -201,7 +202,7 @@ final class IndexManagerTest extends TestCase
         $toIndex = 'to_ ' . self::INDEX;
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateAliases')
             ->with(
                 [
@@ -216,7 +217,7 @@ final class IndexManagerTest extends TestCase
             ->willReturn($response);
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 'Elasticsearch exception: Could not switch alias for index',
@@ -243,7 +244,7 @@ final class IndexManagerTest extends TestCase
         $settings = ['index' => ['number_of_shards' => 5, 'number_of_replicas' => 1]];
 
         return [
-            'completely blank'          => [
+            'completely_blank'         => [
                 'input'                 => [
                     self::INDEX,
                 ],
@@ -251,7 +252,7 @@ final class IndexManagerTest extends TestCase
                     'index' => self::INDEX,
                 ],
             ],
-            'no aliases, no settings'   => [
+            'no_aliases_no_settings'   => [
                 'input'                 => [
                     self::INDEX,
                     self::MAPPING,
@@ -261,7 +262,7 @@ final class IndexManagerTest extends TestCase
                     'body'  => ['mappings' => self::MAPPING],
                 ],
             ],
-            'with alias, no settings'   => [
+            'with_alias_no_settings'   => [
                 'input'                 => [
                     self::INDEX,
                     self::MAPPING,
@@ -272,7 +273,7 @@ final class IndexManagerTest extends TestCase
                     'body'  => ['mappings' => self::MAPPING, 'aliases' => [self::ALIAS => new stdClass()]],
                 ],
             ],
-            'no aliases, with settings' => [
+            'no_aliases_with_settings' => [
                 'input'                 => [
                     self::INDEX,
                     self::MAPPING,
@@ -284,7 +285,7 @@ final class IndexManagerTest extends TestCase
                     'body'  => ['mappings' => self::MAPPING, 'settings' => $settings],
                 ],
             ],
-            'with alias and settings'   => [
+            'with_alias_and_settings'  => [
                 'input'                 => [
                     self::INDEX,
                     self::MAPPING,
@@ -303,36 +304,36 @@ final class IndexManagerTest extends TestCase
         ];
     }
 
-    /** @dataProvider createIndexDataProvider */
+    #[DataProvider('createIndexDataProvider')]
     public function testCreateIndex(array $input, array $expectedRequestBody): void
     {
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('create')
             ->with($expectedRequestBody)
             ->willReturn(['acknowledged' => true]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getManager()->createIndex(...$input);
     }
 
-    /** @dataProvider notAcknowledgedResponseDataProvider */
+    #[DataProvider('notAcknowledgedResponseDataProvider')]
     public function testCreateIndexFails(array $response): void
     {
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('create')
             ->willReturn($response);
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 'Elasticsearch exception: Could not create index',
@@ -358,7 +359,7 @@ final class IndexManagerTest extends TestCase
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('delete')
             ->with(
                 ['index' => self::INDEX]
@@ -366,19 +367,19 @@ final class IndexManagerTest extends TestCase
             ->willReturn(['acknowledged' => true]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getManager()->deleteIndex(self::INDEX);
     }
 
-    /** @dataProvider notAcknowledgedResponseDataProvider */
+    #[DataProvider('notAcknowledgedResponseDataProvider')]
     public function testDeleteIndexFails(array $response): void
     {
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('delete')
             ->with(
                 ['index' => self::INDEX]
@@ -386,7 +387,7 @@ final class IndexManagerTest extends TestCase
             ->willReturn($response);
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 'Elasticsearch exception: Could not delete index',
@@ -404,7 +405,7 @@ final class IndexManagerTest extends TestCase
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('putMapping')
             ->with(
                 [
@@ -416,19 +417,19 @@ final class IndexManagerTest extends TestCase
             ->willReturn(['acknowledged' => true]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getManager()->putMapping(self::INDEX, self::MAPPING, ['extra_param' => true]);
     }
 
-    /** @dataProvider notAcknowledgedResponseDataProvider */
+    #[DataProvider('notAcknowledgedResponseDataProvider')]
     public function testPutMappingFails(array $response): void
     {
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('putMapping')
             ->with(
                 [
@@ -439,7 +440,7 @@ final class IndexManagerTest extends TestCase
             ->willReturn($response);
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 'Elasticsearch exception: Could not put mapping',
@@ -459,28 +460,28 @@ final class IndexManagerTest extends TestCase
     public static function indicesByAliasDataProvider(): array
     {
         return [
-            'no indices mapped to alias'       => [
+            'no_indices_mapped_to_alias'       => [
                 'es_response'     => [],
                 'expected_result' => [],
             ],
-            'one index mapped to alias'        => [
+            'one_index_mapped_to_alias'        => [
                 'es_response'     => [self::INDEX => ['foo' => 'bar']],
                 'expected_result' => [self::INDEX],
             ],
-            'multiple indices mapped to alias' => [
+            'multiple_indices_mapped_to_alias' => [
                 'es_response'     => [self::INDEX => ['foo' => 'bar'], 'another_index' => []],
                 'expected_result' => [self::INDEX, 'another_index'],
             ],
         ];
     }
 
-    /** @dataProvider indicesByAliasDataProvider */
+    #[DataProvider('indicesByAliasDataProvider')]
     public function testGetIndicesByAlias(array $esResponse, array $expectedResult): void
     {
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getAlias')
             ->with(
                 ['name' => self::ALIAS]
@@ -488,10 +489,10 @@ final class IndexManagerTest extends TestCase
             ->willReturn($esResponse);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->assertEquals($expectedResult, $this->getManager()->getIndicesByAlias(self::ALIAS));
+        self::assertEquals($expectedResult, $this->getManager()->getIndicesByAlias(self::ALIAS));
     }
 
     public function testGetIndicesByAliasFails(): void
@@ -499,12 +500,12 @@ final class IndexManagerTest extends TestCase
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getAlias')
             ->willThrowException(new Exception('something happened'));
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 'Elasticsearch exception: Unable to get indices by alias',
@@ -525,33 +526,33 @@ final class IndexManagerTest extends TestCase
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getAlias')
             ->willThrowException(new Missing404Exception());
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->assertEquals([], $this->getManager()->getIndicesByAlias(self::ALIAS));
+        self::assertEquals([], $this->getManager()->getIndicesByAlias(self::ALIAS));
     }
 
     public static function indexAliasMappingDataProvider(): array
     {
         return [
-            'no indices'                             => [
+            'no_indices'                             => [
                 'es_response'     => [],
                 'expected_result' => [],
             ],
-            'one index without alias'                => [
+            'one_index_without_alias'                => [
                 'es_response'     => [self::INDEX => ['aliases' => []]],
                 'expected_result' => [self::INDEX => []],
             ],
-            'one index with one alias'               => [
+            'one_index_with_one_alias'               => [
                 'es_response'     => [self::INDEX => ['aliases' => [self::ALIAS => ['foo' => 'bar']]]],
                 'expected_result' => [self::INDEX => [self::ALIAS]],
             ],
-            'one index with multiple aliases'        => [
+            'one_index_with_multiple_aliases'        => [
                 'es_response'     => [
                     self::INDEX => [
                         'aliases' => [
@@ -562,18 +563,18 @@ final class IndexManagerTest extends TestCase
                 ],
                 'expected_result' => [self::INDEX => [self::ALIAS, 'other_alias']],
             ],
-            'multiple indices without alias'         => [
+            'multiple_indices_without_alias'         => [
                 'es_response'     => [self::INDEX => ['aliases' => []], 'another_index' => ['aliases' => []]],
                 'expected_result' => [self::INDEX => [], 'another_index' => []],
             ],
-            'multiple indices with one alias'        => [
+            'multiple_indices_with_one_alias'        => [
                 'es_response'     => [
                     self::INDEX     => ['aliases' => [self::ALIAS => ['foo' => 'bar']]],
                     'another_index' => ['aliases' => ['fancy_index_alias' => []]],
                 ],
                 'expected_result' => [self::INDEX => [self::ALIAS], 'another_index' => ['fancy_index_alias']],
             ],
-            'multiple indices with multiple aliases' => [
+            'multiple_indices_with_multiple_aliases' => [
                 'es_response'     => [
                     self::INDEX   => ['aliases' => [self::ALIAS => ['foo' => 'bar'], 'other_alias' => []]],
                     'other_index' => ['aliases' => ['my_special_alias' => []]],
@@ -586,13 +587,13 @@ final class IndexManagerTest extends TestCase
         ];
     }
 
-    /** @dataProvider indexAliasMappingDataProvider */
+    #[DataProvider('indexAliasMappingDataProvider')]
     public function testGetIndicesAliasesMapping(array $esResponse, array $expectedResult): void
     {
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with(
                 ['index' => '_all']
@@ -600,10 +601,10 @@ final class IndexManagerTest extends TestCase
             ->willReturn($esResponse);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->assertEquals($expectedResult, $this->getManager()->getIndicesAliasesMapping());
+        self::assertEquals($expectedResult, $this->getManager()->getIndicesAliasesMapping());
     }
 
     public function testGetIndicesAliasesMappingCatches404(): void
@@ -611,7 +612,7 @@ final class IndexManagerTest extends TestCase
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with(
                 ['index' => '_all']
@@ -619,10 +620,10 @@ final class IndexManagerTest extends TestCase
             ->willThrowException(new Missing404Exception());
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->assertEquals([], $this->getManager()->getIndicesAliasesMapping());
+        self::assertEquals([], $this->getManager()->getIndicesAliasesMapping());
     }
 
     public function testGetIndicesAliasesMappingFails(): void
@@ -630,7 +631,7 @@ final class IndexManagerTest extends TestCase
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with(
                 ['index' => '_all']
@@ -638,7 +639,7 @@ final class IndexManagerTest extends TestCase
             ->willThrowException(new Exception('something happened'));
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 'Elasticsearch exception: Unable to get indices',
@@ -656,7 +657,7 @@ final class IndexManagerTest extends TestCase
     public function testReindex(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('reindex')
             ->with(
                 [
@@ -673,7 +674,7 @@ final class IndexManagerTest extends TestCase
             ->willReturn(['acknowledged' => true]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getManager()->reindex(self::INDEX, self::INDEX . '_v2');
@@ -682,12 +683,12 @@ final class IndexManagerTest extends TestCase
     public function testReindexFails(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('reindex')
             ->willThrowException(new Exception('something happened'));
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 'Elasticsearch exception: Unable to reindex',
@@ -707,12 +708,12 @@ final class IndexManagerTest extends TestCase
     public function testPutSettings(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('indices')
             ->willReturn($this->indicesMock);
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('putSettings')
             ->with([
                 'index' => 'test',
@@ -737,11 +738,11 @@ final class IndexManagerTest extends TestCase
     public function testDisallowedPutSettings(): void
     {
         $this->clientMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('indices');
 
         $this->indicesMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('putSettings');
 
         $this->expectException(IndexManagementException::class);
@@ -760,11 +761,11 @@ final class IndexManagerTest extends TestCase
     public function testAllowedAndDisallowedPutSettings(): void
     {
         $this->clientMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('indices');
 
         $this->indicesMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('putSettings');
 
         $this->expectException(IndexManagementException::class);
@@ -781,13 +782,13 @@ final class IndexManagerTest extends TestCase
         );
     }
 
-    /** @dataProvider getSingleIndexByAliasDataProvider */
+    #[DataProvider('getSingleIndexByAliasDataProvider')]
     public function testGetSingleIndexByAlias(array $esResponse, ?string $expectedResult): void
     {
         $this->setUpIndexOperation();
 
         $this->indicesMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getAlias')
             ->with(['name' => self::ALIAS])
             ->willReturn($esResponse);
@@ -801,26 +802,26 @@ final class IndexManagerTest extends TestCase
         }
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $result = $this->getManager()->getSingleIndexByAlias(self::ALIAS);
 
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     public static function getSingleIndexByAliasDataProvider(): array
     {
         return [
-            'no indices mapped to alias'       => [
+            'no_indices_mapped_to_alias'       => [
                 'es_response'     => [],
                 'expected_result' => null,
             ],
-            'one index mapped to alias'        => [
+            'one_index_mapped_to_alias'        => [
                 'es_response'     => [self::INDEX => ['foo' => 'bar']],
                 'expected_result' => self::INDEX,
             ],
-            'multiple indices mapped to alias' => [
+            'multiple_indices_mapped_to_alias' => [
                 'es_response'     => [self::INDEX => ['foo' => 'bar'], 'another_index' => []],
                 'expected_result' => null,
             ],
@@ -846,7 +847,7 @@ final class IndexManagerTest extends TestCase
     private function setUpIndexOperation(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('indices')
             ->willReturn($this->indicesMock);
     }

--- a/tests/Query/AbstractQueryTest.php
+++ b/tests/Query/AbstractQueryTest.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 use Kununu\Elasticsearch\Query\AbstractQuery;
 use Kununu\Elasticsearch\Query\QueryInterface;
 use Kununu\Elasticsearch\Query\SortOrder;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AbstractQueryTest extends TestCase
@@ -15,33 +16,33 @@ final class AbstractQueryTest extends TestCase
     {
         $query = $this->getQuery();
 
-        $this->assertEquals([], $query->toArray());
+        self::assertEquals([], $query->toArray());
     }
 
-    /** @dataProvider selectDataProvider */
+    #[DataProvider('selectDataProvider')]
     public function testSelect(mixed $input, mixed $expectedOutput): void
     {
         $query = $this->getQuery();
 
-        $this->assertNull($query->getSelect());
-        $this->assertEquals([], $query->toArray());
+        self::assertNull($query->getSelect());
+        self::assertEquals([], $query->toArray());
 
         $query->select($input);
 
-        $this->assertEquals($input, $query->getSelect());
+        self::assertEquals($input, $query->getSelect());
         $serialized = $query->toArray();
-        $this->assertArrayHasKey('_source', $serialized);
-        $this->assertEquals($expectedOutput, $serialized['_source']);
+        self::assertArrayHasKey('_source', $serialized);
+        self::assertEquals($expectedOutput, $serialized['_source']);
     }
 
     public static function selectDataProvider(): array
     {
         return [
-            'no field'         => [
+            'no_field'         => [
                 'input'           => [],
                 'expected_output' => false,
             ],
-            'one field'        => [
+            'one_field'        => [
                 'input'           => [
                     'foo',
                 ],
@@ -49,7 +50,7 @@ final class AbstractQueryTest extends TestCase
                     'foo',
                 ],
             ],
-            'two fields'       => [
+            'two_fields'       => [
                 'input'           => [
                     'foo',
                     'bar',
@@ -59,7 +60,7 @@ final class AbstractQueryTest extends TestCase
                     'bar',
                 ],
             ],
-            'same field twice' => [
+            'same_field_twice' => [
                 'input'           => [
                     'foo',
                     'foo',
@@ -75,66 +76,66 @@ final class AbstractQueryTest extends TestCase
     {
         $query = $this->getQuery();
 
-        $this->assertNull($query->getOffset());
-        $this->assertEquals([], $query->toArray());
+        self::assertNull($query->getOffset());
+        self::assertEquals([], $query->toArray());
 
         $query->skip(10);
 
-        $this->assertEquals(10, $query->getOffset());
-        $this->assertNull($query->getLimit());
-        $this->assertEquals([], $query->getSort());
-        $this->assertEquals(['from' => 10], $query->toArray());
+        self::assertEquals(10, $query->getOffset());
+        self::assertNull($query->getLimit());
+        self::assertEquals([], $query->getSort());
+        self::assertEquals(['from' => 10], $query->toArray());
 
         // override offset
         $query->skip(20);
 
-        $this->assertEquals(20, $query->getOffset());
-        $this->assertEquals(['from' => 20], $query->toArray());
+        self::assertEquals(20, $query->getOffset());
+        self::assertEquals(['from' => 20], $query->toArray());
     }
 
     public function testLimit(): void
     {
         $query = $this->getQuery();
 
-        $this->assertNull($query->getLimit());
-        $this->assertEquals([], $query->toArray());
+        self::assertNull($query->getLimit());
+        self::assertEquals([], $query->toArray());
 
         $query->limit(10);
 
-        $this->assertEquals(10, $query->getLimit());
-        $this->assertNull($query->getOffset());
-        $this->assertEquals([], $query->getSort());
-        $this->assertEquals(['size' => 10], $query->toArray());
+        self::assertEquals(10, $query->getLimit());
+        self::assertNull($query->getOffset());
+        self::assertEquals([], $query->getSort());
+        self::assertEquals(['size' => 10], $query->toArray());
 
         // override limit
         $query->limit(20);
 
-        $this->assertEquals(20, $query->getLimit());
-        $this->assertEquals(['size' => 20], $query->toArray());
+        self::assertEquals(20, $query->getLimit());
+        self::assertEquals(['size' => 20], $query->toArray());
     }
 
-    /** @dataProvider sortDataProvider */
+    #[DataProvider('sortDataProvider')]
     public function testSort(array $input, array $expectedOutput): void
     {
         $query = $this->getQuery();
 
-        $this->assertEquals([], $query->getSort());
-        $this->assertEquals([], $query->toArray());
+        self::assertEquals([], $query->getSort());
+        self::assertEquals([], $query->toArray());
 
         foreach ($input as $command) {
             $query->sort($command['key'], $command['order'], $command['options'] ?? []);
         }
 
-        $this->assertNull($query->getOffset());
-        $this->assertNull($query->getLimit());
-        $this->assertEquals($expectedOutput, $query->getSort());
-        $this->assertEquals(['sort' => $expectedOutput], $query->toArray());
+        self::assertNull($query->getOffset());
+        self::assertNull($query->getLimit());
+        self::assertEquals($expectedOutput, $query->getSort());
+        self::assertEquals(['sort' => $expectedOutput], $query->toArray());
     }
 
     public static function sortDataProvider(): array
     {
         return [
-            'one field'               => [
+            'one_field'               => [
                 'input'           => [
                     [
                         'key'   => 'foo',
@@ -145,7 +146,7 @@ final class AbstractQueryTest extends TestCase
                     'foo' => ['order' => SortOrder::ASC],
                 ],
             ],
-            'two fields'              => [
+            'two_fields'              => [
                 'input'           => [
                     [
                         'key'   => 'foo',
@@ -161,7 +162,7 @@ final class AbstractQueryTest extends TestCase
                     'bar' => ['order' => SortOrder::DESC],
                 ],
             ],
-            'override one field'      => [
+            'override_one_field'      => [
                 'input'           => [
                     [
                         'key'   => 'foo',
@@ -176,7 +177,7 @@ final class AbstractQueryTest extends TestCase
                     'foo' => ['order' => SortOrder::DESC],
                 ],
             ],
-            'one field with options'  => [
+            'one_field_with_options'  => [
                 'input'           => [
                     [
                         'key'     => 'foo',
@@ -188,7 +189,7 @@ final class AbstractQueryTest extends TestCase
                     'foo' => ['order' => SortOrder::ASC, 'missing' => '_last'],
                 ],
             ],
-            'two fields with options' => [
+            'two_fields_with_options' => [
                 'input'           => [
                     [
                         'key'     => 'foo',
@@ -209,13 +210,13 @@ final class AbstractQueryTest extends TestCase
         ];
     }
 
-    /** @dataProvider sortDataProvider */
+    #[DataProvider('sortDataProvider')]
     public function testMultipleSort(array $input, array $expectedOutput): void
     {
         $query = $this->getQuery();
 
-        $this->assertEquals([], $query->getSort());
-        $this->assertEquals([], $query->toArray());
+        self::assertEquals([], $query->getSort());
+        self::assertEquals([], $query->toArray());
 
         $combinedInput = array_reduce(
             $input,
@@ -229,10 +230,10 @@ final class AbstractQueryTest extends TestCase
 
         $query->sort($combinedInput);
 
-        $this->assertNull($query->getOffset());
-        $this->assertNull($query->getLimit());
-        $this->assertEquals($expectedOutput, $query->getSort());
-        $this->assertEquals(['sort' => $expectedOutput], $query->toArray());
+        self::assertNull($query->getOffset());
+        self::assertNull($query->getLimit());
+        self::assertEquals($expectedOutput, $query->getSort());
+        self::assertEquals(['sort' => $expectedOutput], $query->toArray());
     }
 
     public function testSortInvalidOrder(): void

--- a/tests/Query/AggregationTest.php
+++ b/tests/Query/AggregationTest.php
@@ -7,18 +7,19 @@ use InvalidArgumentException;
 use Kununu\Elasticsearch\Query\Aggregation;
 use Kununu\Elasticsearch\Query\Aggregation\Bucket;
 use Kununu\Elasticsearch\Query\Aggregation\Metric;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 final class AggregationTest extends TestCase
 {
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testCreateWithoutOptions(string $field, string $type, string $name): void
     {
         $aggregation = Aggregation::create($field, $type, $name);
 
-        $this->assertEquals($name, $aggregation->getName());
-        $this->assertEquals(
+        self::assertEquals($name, $aggregation->getName());
+        self::assertEquals(
             [
                 $name => [
                     $type => [
@@ -34,7 +35,7 @@ final class AggregationTest extends TestCase
     {
         $ret = [];
         foreach (Metric::all() + Bucket::all() as $type) {
-            $ret['type ' . $type] = [
+            $ret['type_' . $type] = [
                 'field'   => 'my_field',
                 'type'    => $type,
                 'name'    => 'my_agg',
@@ -58,7 +59,7 @@ final class AggregationTest extends TestCase
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'my_agg' => [
                     'sum' => [
@@ -75,7 +76,7 @@ final class AggregationTest extends TestCase
     {
         $aggregation = Aggregation::create('my_field', Metric::SUM);
 
-        $this->assertNotNull($aggregation->getName());
+        self::assertNotNull($aggregation->getName());
     }
 
     public function testCreateWithInvalidType(): void
@@ -91,7 +92,7 @@ final class AggregationTest extends TestCase
         $aggregation = Aggregation::create('my_field', Bucket::TERMS, 'my_term_buckets')
             ->nest(Aggregation::create('my_field', Metric::CARDINALITY, 'term_cardinality'));
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'my_term_buckets' => [
                     'terms' => [
@@ -116,7 +117,7 @@ final class AggregationTest extends TestCase
             ->nest(Aggregation::create('my_field', Metric::CARDINALITY, 'term_cardinality'))
             ->nest(Aggregation::create('my_field', Metric::VALUE_COUNT, 'term_value_count'));
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'my_term_buckets' => [
                     'terms' => [
@@ -144,7 +145,7 @@ final class AggregationTest extends TestCase
     {
         $aggregation = Aggregation::createGlobal('my_global_agg');
 
-        $this->assertEquals(
+        self::assertEquals(
             json_encode(
                 [
                     'my_global_agg' => [
@@ -160,7 +161,7 @@ final class AggregationTest extends TestCase
     {
         $aggregation = Aggregation::createGlobal('my_global_agg', ['my_option' => 'foobar']);
 
-        $this->assertEquals(
+        self::assertEquals(
             json_encode(
                 [
                     'my_global_agg' => [
@@ -178,7 +179,7 @@ final class AggregationTest extends TestCase
         $aggregation = Aggregation::createGlobal('all_products')
             ->nest(Aggregation::create('price', Metric::AVG, 'avg_price'));
 
-        $this->assertEquals(
+        self::assertEquals(
             json_encode(
                 [
                     'all_products' => [
@@ -201,7 +202,7 @@ final class AggregationTest extends TestCase
     {
         $aggregation = Aggregation::createFieldless(Bucket::FILTERS, 'my_fieldless_agg');
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'my_fieldless_agg' => [
                     'filters' => [],
@@ -219,7 +220,7 @@ final class AggregationTest extends TestCase
             ['other_bucket_key' => 'foobar', 'filters' => ['bucket_a' => ['term' => ['field' => 'field_a']]]]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'my_fieldless_agg' => [
                     'filters' => [
@@ -241,15 +242,18 @@ final class AggregationTest extends TestCase
             ['ranges' => [['from' => 1, 'to' => 2]]]
         );
 
-        $this->assertEquals([
-            'my_agg' => [
-                'range' => [
-                    'field'       => 'my_field',
-                    'ranges'      => [
-                        ['from' => 1, 'to' => 2],
+        self::assertEquals(
+            [
+                'my_agg' => [
+                    'range' => [
+                        'field'  => 'my_field',
+                        'ranges' => [
+                            ['from' => 1, 'to' => 2],
+                        ],
                     ],
                 ],
             ],
-        ], $aggregation->toArray());
+            $aggregation->toArray()
+        );
     }
 }

--- a/tests/Query/Criteria/Bool/BoolQueryTest.php
+++ b/tests/Query/Criteria/Bool/BoolQueryTest.php
@@ -7,6 +7,7 @@ use Kununu\Elasticsearch\Query\Criteria\Bool\AbstractBoolQuery;
 use Kununu\Elasticsearch\Query\Criteria\Bool\BoolQueryInterface;
 use Kununu\Elasticsearch\Query\Criteria\Filter;
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class BoolQueryTest extends TestCase
@@ -26,10 +27,10 @@ final class BoolQueryTest extends TestCase
         $myBoolFilter->getOperator();
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testCreate(array $input): void
     {
-        $this->assertEquals($input, $this->getConcreteBoolQuery($input)->getChildren());
+        self::assertEquals($input, $this->getConcreteBoolQuery($input)->getChildren());
     }
 
     public static function createDataProvider(): array
@@ -38,10 +39,10 @@ final class BoolQueryTest extends TestCase
             'empty'                   => [
                 'input' => [],
             ],
-            'with a filter'           => [
+            'with_a_filter'           => [
                 'input' => [Filter::create('field', 'value')],
             ],
-            'with two filters search' => [
+            'with_two_filters_search' => [
                 'input' => [
                     Filter::create('field', 'value'),
                     Filter::create('another_field', 'another_value'),
@@ -50,32 +51,32 @@ final class BoolQueryTest extends TestCase
         ];
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testAdd(array $input): void
     {
         $boolQuery = $this->getConcreteBoolQuery([]);
 
-        $this->assertEquals([], $boolQuery->getChildren());
+        self::assertEquals([], $boolQuery->getChildren());
 
         foreach ($input as $child) {
             $boolQuery->add($child);
         }
 
-        $this->assertEquals($input, $boolQuery->getChildren());
+        self::assertEquals($input, $boolQuery->getChildren());
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testToArray(array $input): void
     {
         $boolQuery = $this->getConcreteBoolQuery($input);
 
-        $this->assertEquals($input, $boolQuery->getChildren());
+        self::assertEquals($input, $boolQuery->getChildren());
 
         $serialized = $boolQuery->toArray();
 
-        $this->assertArrayHasKey('bool', $serialized);
-        $this->assertArrayHasKey('my_operator', $serialized['bool']);
-        $this->assertCount(count($input), $serialized['bool']['my_operator']);
+        self::assertArrayHasKey('bool', $serialized);
+        self::assertArrayHasKey('my_operator', $serialized['bool']);
+        self::assertCount(count($input), $serialized['bool']['my_operator']);
     }
 
     private function getConcreteBoolQuery(array $input): BoolQueryInterface

--- a/tests/Query/Criteria/Bool/MustNotTest.php
+++ b/tests/Query/Criteria/Bool/MustNotTest.php
@@ -10,6 +10,6 @@ final class MustNotTest extends TestCase
 {
     public function testOperator(): void
     {
-        $this->assertEquals('must_not', MustNot::OPERATOR);
+        self::assertEquals('must_not', MustNot::OPERATOR);
     }
 }

--- a/tests/Query/Criteria/Bool/MustTest.php
+++ b/tests/Query/Criteria/Bool/MustTest.php
@@ -10,6 +10,6 @@ final class MustTest extends TestCase
 {
     public function testOperator(): void
     {
-        $this->assertEquals('must', Must::OPERATOR);
+        self::assertEquals('must', Must::OPERATOR);
     }
 }

--- a/tests/Query/Criteria/Bool/ShouldTest.php
+++ b/tests/Query/Criteria/Bool/ShouldTest.php
@@ -10,6 +10,6 @@ final class ShouldTest extends TestCase
 {
     public function testOperator(): void
     {
-        $this->assertEquals('should', Should::OPERATOR);
+        self::assertEquals('should', Should::OPERATOR);
     }
 }

--- a/tests/Query/Criteria/Filter/ExistsTest.php
+++ b/tests/Query/Criteria/Filter/ExistsTest.php
@@ -10,7 +10,7 @@ final class ExistsTest extends TestCase
 {
     public function testTrue(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'exists' => [
                     'field' => 'field_a',
@@ -22,7 +22,7 @@ final class ExistsTest extends TestCase
 
     public function testFalse(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'bool' => [
                     'must_not' => [

--- a/tests/Query/Criteria/Filter/GeoDistanceTest.php
+++ b/tests/Query/Criteria/Filter/GeoDistanceTest.php
@@ -10,11 +10,11 @@ use PHPUnit\Framework\TestCase;
 
 final class GeoDistanceTest extends TestCase
 {
-    protected GeoDistanceInterface|MockObject $geoDistance;
+    protected MockObject&GeoDistanceInterface $geoDistance;
 
     public function testWithoutOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'geo_distance' => [
                     'distance' => '42km',
@@ -27,7 +27,7 @@ final class GeoDistanceTest extends TestCase
 
     public function testWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'geo_distance' => [
                     'distance'      => '42km',
@@ -44,12 +44,12 @@ final class GeoDistanceTest extends TestCase
         $this->geoDistance = $this->createMock(GeoDistanceInterface::class);
 
         $this->geoDistance
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getDistance')
             ->willReturn('42km');
 
         $this->geoDistance
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getLocation')
             ->willReturn([0, 0]);
     }

--- a/tests/Query/Criteria/Filter/GeoShapeTest.php
+++ b/tests/Query/Criteria/Filter/GeoShapeTest.php
@@ -10,11 +10,11 @@ use PHPUnit\Framework\TestCase;
 
 final class GeoShapeTest extends TestCase
 {
-    protected GeoShapeInterface|MockObject $geoShape;
+    protected MockObject&GeoShapeInterface $geoShape;
 
     public function testWithoutOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'geo_shape' => [
                     'field_a' => [
@@ -28,7 +28,7 @@ final class GeoShapeTest extends TestCase
 
     public function testWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'geo_shape' => [
                     'field_a' => [
@@ -46,7 +46,7 @@ final class GeoShapeTest extends TestCase
         $this->geoShape = $this->createMock(GeoShapeInterface::class);
 
         $this->geoShape
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('toArray')
             ->willReturn([]);
     }

--- a/tests/Query/Criteria/Filter/PrefixTest.php
+++ b/tests/Query/Criteria/Filter/PrefixTest.php
@@ -10,7 +10,7 @@ final class PrefixTest extends TestCase
 {
     public function testWithoutOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'prefix' => [
                     'field_a' => 'foo',
@@ -22,7 +22,7 @@ final class PrefixTest extends TestCase
 
     public function testWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'prefix' => [
                     'field_a' => 'foo',

--- a/tests/Query/Criteria/Filter/RangeTest.php
+++ b/tests/Query/Criteria/Filter/RangeTest.php
@@ -11,7 +11,7 @@ final class RangeTest extends TestCase
 {
     public function testOneElementWithoutOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'range' => [
                     'field_a' => [
@@ -25,7 +25,7 @@ final class RangeTest extends TestCase
 
     public function testMultipleElementsWithoutOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'range' => [
                     'field_a' => [
@@ -40,7 +40,7 @@ final class RangeTest extends TestCase
 
     public function testOneElementWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'range' => [
                     'field_a' => [
@@ -55,7 +55,7 @@ final class RangeTest extends TestCase
 
     public function testMultipleElementsWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'range' => [
                     'field_a' => [

--- a/tests/Query/Criteria/Filter/RegexpTest.php
+++ b/tests/Query/Criteria/Filter/RegexpTest.php
@@ -10,7 +10,7 @@ final class RegexpTest extends TestCase
 {
     public function testWithoutOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'regexp' => [
                     'field_a' => 'foo',
@@ -22,7 +22,7 @@ final class RegexpTest extends TestCase
 
     public function testWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'regexp' => [
                     'field_a' => [

--- a/tests/Query/Criteria/Filter/TermTest.php
+++ b/tests/Query/Criteria/Filter/TermTest.php
@@ -10,7 +10,7 @@ final class TermTest extends TestCase
 {
     public function testWithoutOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'term' => [
                     'field_a' => 'foo',
@@ -22,7 +22,7 @@ final class TermTest extends TestCase
 
     public function testWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'term' => [
                     'field_a' => [

--- a/tests/Query/Criteria/Filter/TermsTest.php
+++ b/tests/Query/Criteria/Filter/TermsTest.php
@@ -10,7 +10,7 @@ final class TermsTest extends TestCase
 {
     public function testWithoutOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'terms' => [
                     'field_a' => ['foo', 'bar'],
@@ -22,7 +22,7 @@ final class TermsTest extends TestCase
 
     public function testWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'terms' => [
                     'field_a' => ['foo', 'bar'],

--- a/tests/Query/Criteria/FilterTest.php
+++ b/tests/Query/Criteria/FilterTest.php
@@ -8,6 +8,7 @@ use Kununu\Elasticsearch\Query\Criteria\Filter;
 use Kununu\Elasticsearch\Query\Criteria\GeoDistanceInterface;
 use Kununu\Elasticsearch\Query\Criteria\GeoShapeInterface;
 use Kununu\Elasticsearch\Query\Criteria\Operator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class FilterTest extends TestCase
@@ -20,15 +21,15 @@ final class FilterTest extends TestCase
         Filter::create('my_field', 'foo', 'bar');
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testCreate(string $operator, mixed $value): void
     {
         $serialized = Filter::create('my_field', $value, $operator)->toArray();
 
-        $this->assertNotEmpty($serialized);
+        self::assertNotEmpty($serialized);
     }
 
-    public function createDataProvider(): array
+    public static function createDataProvider(): array
     {
         $ret = [];
 
@@ -54,8 +55,8 @@ final class FilterTest extends TestCase
     {
         $serialized = Filter::create('my_field', 'value')->toArray();
 
-        $this->assertNotEmpty($serialized);
-        $this->assertArrayHasKey('term', $serialized);
+        self::assertNotEmpty($serialized);
+        self::assertArrayHasKey('term', $serialized);
     }
 
     public function testCreateGeoShape(): void
@@ -63,14 +64,14 @@ final class FilterTest extends TestCase
         $geoShape = $this->createMock(GeoShapeInterface::class);
 
         $geoShape
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('toArray')
             ->willReturn([]);
 
         $serialized = Filter::create('my_field', $geoShape, Operator::GEO_SHAPE)->toArray();
 
-        $this->assertNotEmpty($serialized);
-        $this->assertArrayHasKey('geo_shape', $serialized);
+        self::assertNotEmpty($serialized);
+        self::assertArrayHasKey('geo_shape', $serialized);
     }
 
     public function testCreateGeoDistance(): void
@@ -78,18 +79,18 @@ final class FilterTest extends TestCase
         $geoDistance = $this->createMock(GeoDistanceInterface::class);
 
         $geoDistance
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getDistance')
             ->willReturn('42km');
 
         $geoDistance
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getLocation')
             ->willReturn([0, 0]);
 
         $serialized = Filter::create('my_field', $geoDistance, Operator::GEO_DISTANCE)->toArray();
 
-        $this->assertNotEmpty($serialized);
-        $this->assertArrayHasKey('geo_distance', $serialized);
+        self::assertNotEmpty($serialized);
+        self::assertArrayHasKey('geo_distance', $serialized);
     }
 }

--- a/tests/Query/Criteria/Search/MatchPhrasePrefixQueryTest.php
+++ b/tests/Query/Criteria/Search/MatchPhrasePrefixQueryTest.php
@@ -8,11 +8,11 @@ use PHPUnit\Framework\TestCase;
 
 final class MatchPhrasePrefixQueryTest extends TestCase
 {
-    protected const QUERY_STRING = 'what was i looking for?';
+    private const QUERY_STRING = 'what was i looking for?';
 
     public function testSingleField(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'match_phrase_prefix' => [
                     'field_a' => [
@@ -26,7 +26,7 @@ final class MatchPhrasePrefixQueryTest extends TestCase
 
     public function testSingleFieldWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'match_phrase_prefix' => [
                     'field_a' => [

--- a/tests/Query/Criteria/Search/MatchPhraseQueryTest.php
+++ b/tests/Query/Criteria/Search/MatchPhraseQueryTest.php
@@ -8,11 +8,11 @@ use PHPUnit\Framework\TestCase;
 
 final class MatchPhraseQueryTest extends TestCase
 {
-    protected const QUERY_STRING = 'what was i looking for?';
+    private const QUERY_STRING = 'what was i looking for?';
 
     public function testSingleField(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'match_phrase' => [
                     'field_a' => [
@@ -26,7 +26,7 @@ final class MatchPhraseQueryTest extends TestCase
 
     public function testSingleFieldWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'match_phrase' => [
                     'field_a' => [

--- a/tests/Query/Criteria/Search/MatchQueryTest.php
+++ b/tests/Query/Criteria/Search/MatchQueryTest.php
@@ -8,11 +8,11 @@ use PHPUnit\Framework\TestCase;
 
 final class MatchQueryTest extends TestCase
 {
-    protected const QUERY_STRING = 'what was i looking for?';
+    private const QUERY_STRING = 'what was i looking for?';
 
     public function testSingleField(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'match' => [
                     'field_a' => [
@@ -26,7 +26,7 @@ final class MatchQueryTest extends TestCase
 
     public function testMultipleFields(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'multi_match' => [
                     'fields' => ['field_a', 'field_b'],
@@ -39,7 +39,7 @@ final class MatchQueryTest extends TestCase
 
     public function testSingleFieldWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'match' => [
                     'field_a' => [
@@ -54,7 +54,7 @@ final class MatchQueryTest extends TestCase
 
     public function testMultipleFieldsWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'multi_match' => [
                     'fields' => ['field_a', 'field_b'],

--- a/tests/Query/Criteria/Search/MultiFieldTraitTest.php
+++ b/tests/Query/Criteria/Search/MultiFieldTraitTest.php
@@ -4,36 +4,37 @@ declare(strict_types=1);
 namespace Kununu\Elasticsearch\Tests\Query\Criteria\Search;
 
 use Kununu\Elasticsearch\Query\Criteria\Search\MultiFieldTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class MultiFieldTraitTest extends TestCase
 {
-    /** @dataProvider boostPreparationDataProvider */
+    #[DataProvider('boostPreparationDataProvider')]
     public function testBoostPreparation(array $input, array $expectedOutput): void
     {
-        $this->assertEquals($expectedOutput, $this->getMultiFieldCapableObject()->publiclyPrepare($input));
+        self::assertEquals($expectedOutput, $this->getMultiFieldCapableObject()->prepareFields($input));
     }
 
     public static function boostPreparationDataProvider(): array
     {
         return [
-            'single field, without boost'             => [
+            'single_field_without_boost'             => [
                 'input'          => ['my_field'],
                 'expectedOutput' => ['my_field'],
             ],
-            'multiple fields, without boost'          => [
+            'multiple_fields_without_boost'          => [
                 'input'          => ['field_a', 'field_b'],
                 'expectedOutput' => ['field_a', 'field_b'],
             ],
-            'single field, with boost'                => [
+            'single_field_with_boost'                => [
                 'input'          => ['my_field' => ['boost' => 7]],
                 'expectedOutput' => ['my_field^7'],
             ],
-            'multiple fields, with boost'             => [
+            'multiple_fields_with_boost'             => [
                 'input'          => ['field_a' => ['boost' => 7], 'field_b' => ['boost' => 42]],
                 'expectedOutput' => ['field_a^7', 'field_b^42'],
             ],
-            'multiple fields, with and without boost' => [
+            'multiple_fields_with_and_without_boost' => [
                 'input'          => ['field_a' => ['boost' => 7], 'field_b'],
                 'expectedOutput' => ['field_a^7', 'field_b'],
             ],
@@ -43,11 +44,13 @@ final class MultiFieldTraitTest extends TestCase
     private function getMultiFieldCapableObject(): object
     {
         return new class() {
-            use MultiFieldTrait;
+            use MultiFieldTrait {
+                prepareFields as traitPrepareFields;
+            }
 
-            public function publiclyPrepare(array $fields): array
+            public function prepareFields(array $fields): array
             {
-                return $this->prepareFields($fields);
+                return self::traitPrepareFields($fields);
             }
         };
     }

--- a/tests/Query/Criteria/Search/PrefixQueryTest.php
+++ b/tests/Query/Criteria/Search/PrefixQueryTest.php
@@ -8,11 +8,11 @@ use PHPUnit\Framework\TestCase;
 
 final class PrefixQueryTest extends TestCase
 {
-    protected const QUERY_STRING = 'what was i looking for?';
+    private const QUERY_STRING = 'what was i looking for?';
 
     public function testSingleField(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'prefix' => [
                     'field_a' => [
@@ -26,7 +26,7 @@ final class PrefixQueryTest extends TestCase
 
     public function testSingleFieldWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'prefix' => [
                     'field_a' => [

--- a/tests/Query/Criteria/Search/QueryStringQueryTest.php
+++ b/tests/Query/Criteria/Search/QueryStringQueryTest.php
@@ -8,11 +8,11 @@ use PHPUnit\Framework\TestCase;
 
 final class QueryStringQueryTest extends TestCase
 {
-    protected const QUERY_STRING = 'what was i looking for?';
+    private const QUERY_STRING = 'what was i looking for?';
 
     public function testSingleField(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'query_string' => [
                     'fields' => ['field_a'],
@@ -25,7 +25,7 @@ final class QueryStringQueryTest extends TestCase
 
     public function testMultipleFields(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'query_string' => [
                     'fields' => ['field_a', 'field_b'],
@@ -38,7 +38,7 @@ final class QueryStringQueryTest extends TestCase
 
     public function testWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'query_string' => [
                     'fields' => ['field_a', 'field_b'],

--- a/tests/Query/Criteria/Search/TermQueryTest.php
+++ b/tests/Query/Criteria/Search/TermQueryTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase;
 
 final class TermQueryTest extends TestCase
 {
-    protected const TERM = 'what was i looking for?';
-    protected const FIELD = 'field_a';
+    private const TERM = 'what was i looking for?';
+    private const FIELD = 'field_a';
 
     public function testSingleField(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'term' => [
                     self::FIELD => [
@@ -27,7 +27,7 @@ final class TermQueryTest extends TestCase
 
     public function testSingleFieldWithOptions(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'term' => [
                     self::FIELD => [

--- a/tests/Query/Criteria/SearchTest.php
+++ b/tests/Query/Criteria/SearchTest.php
@@ -5,6 +5,7 @@ namespace Kununu\Elasticsearch\Tests\Query\Criteria;
 
 use InvalidArgumentException;
 use Kununu\Elasticsearch\Query\Criteria\Search;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class SearchTest extends TestCase
@@ -25,13 +26,13 @@ final class SearchTest extends TestCase
         Search::create(['my_field'], 'foo', 'bar');
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testCreate(string $type): void
     {
         $serialized = Search::create(['my_field'], 'i am looking for something', $type)->toArray();
 
-        $this->assertNotEmpty($serialized);
-        $this->assertArrayHasKey($type, $serialized);
+        self::assertNotEmpty($serialized);
+        self::assertArrayHasKey($type, $serialized);
     }
 
     public static function createDataProvider(): array

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -17,6 +17,7 @@ use Kununu\Elasticsearch\Query\Criteria\Search;
 use Kununu\Elasticsearch\Query\Criteria\SearchInterface;
 use Kununu\Elasticsearch\Query\Query;
 use Kununu\Elasticsearch\Query\SortOrder;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -26,7 +27,7 @@ final class QueryTest extends TestCase
     private const FIELD_NAME_FILTERS = 'filters';
     private const FIELD_NAME_AGGREGATIONS = 'aggregations';
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testCreate(array $input): void
     {
         $children = [
@@ -41,9 +42,9 @@ final class QueryTest extends TestCase
 
         $query = Query::create(...$input);
 
-        $this->assertChildren($query, self::FIELD_NAME_SEARCHES, $children[Search::class]);
-        $this->assertChildren($query, self::FIELD_NAME_FILTERS, $children[Filter::class]);
-        $this->assertChildren($query, self::FIELD_NAME_AGGREGATIONS, $children[Aggregation::class]);
+        self::assertChildren($query, self::FIELD_NAME_SEARCHES, $children[Search::class]);
+        self::assertChildren($query, self::FIELD_NAME_FILTERS, $children[Filter::class]);
+        self::assertChildren($query, self::FIELD_NAME_AGGREGATIONS, $children[Aggregation::class]);
     }
 
     public static function createDataProvider(): array
@@ -52,16 +53,16 @@ final class QueryTest extends TestCase
             'empty'                           => [
                 'input' => [],
             ],
-            'with a filter'                   => [
+            'with_a_filter'                   => [
                 'input' => [Filter::create('field', 'value')],
             ],
-            'with a search'                   => [
+            'with_a_search'                   => [
                 'input' => [Search::create(['field'], 'value')],
             ],
-            'with an aggregation'             => [
+            'with_an_aggregation'             => [
                 'input' => [Aggregation::create('field', Metric::SUM)],
             ],
-            'with a little bit of everything' => [
+            'with_a_little_bit_of_everything' => [
                 'input' => [
                     Filter::create('field', 'value'),
                     Search::create(['field'], 'value'),
@@ -71,7 +72,7 @@ final class QueryTest extends TestCase
         ];
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testCreateNested(array $input): void
     {
         $children = [
@@ -88,15 +89,15 @@ final class QueryTest extends TestCase
 
         $query = Query::createNested($path, ...$input);
 
-        $this->assertChildren($query, self::FIELD_NAME_SEARCHES, $children[Search::class]);
-        $this->assertChildren($query, self::FIELD_NAME_FILTERS, $children[Filter::class]);
-        $this->assertChildren($query, self::FIELD_NAME_AGGREGATIONS, $children[Aggregation::class]);
-        $this->assertEquals($path, $query->getOption(NestableQueryInterface::OPTION_PATH));
-        $this->assertNull($query->getOption(NestableQueryInterface::OPTION_IGNORE_UNMAPPED));
-        $this->assertNull($query->getOption(NestableQueryInterface::OPTION_SCORE_MODE));
+        self::assertChildren($query, self::FIELD_NAME_SEARCHES, $children[Search::class]);
+        self::assertChildren($query, self::FIELD_NAME_FILTERS, $children[Filter::class]);
+        self::assertChildren($query, self::FIELD_NAME_AGGREGATIONS, $children[Aggregation::class]);
+        self::assertEquals($path, $query->getOption(NestableQueryInterface::OPTION_PATH));
+        self::assertNull($query->getOption(NestableQueryInterface::OPTION_IGNORE_UNMAPPED));
+        self::assertNull($query->getOption(NestableQueryInterface::OPTION_SCORE_MODE));
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testAdd(array $input): void
     {
         $children = [
@@ -107,18 +108,18 @@ final class QueryTest extends TestCase
 
         $query = Query::create();
 
-        $this->assertChildren($query, self::FIELD_NAME_SEARCHES, $children[Search::class]);
-        $this->assertChildren($query, self::FIELD_NAME_FILTERS, $children[Filter::class]);
-        $this->assertChildren($query, self::FIELD_NAME_AGGREGATIONS, $children[Aggregation::class]);
+        self::assertChildren($query, self::FIELD_NAME_SEARCHES, $children[Search::class]);
+        self::assertChildren($query, self::FIELD_NAME_FILTERS, $children[Filter::class]);
+        self::assertChildren($query, self::FIELD_NAME_AGGREGATIONS, $children[Aggregation::class]);
 
         foreach ($input as $child) {
             $children[$child::class][] = $child;
             $query->add($child);
         }
 
-        $this->assertChildren($query, self::FIELD_NAME_SEARCHES, $children[Search::class]);
-        $this->assertChildren($query, self::FIELD_NAME_FILTERS, $children[Filter::class]);
-        $this->assertChildren($query, self::FIELD_NAME_AGGREGATIONS, $children[Aggregation::class]);
+        self::assertChildren($query, self::FIELD_NAME_SEARCHES, $children[Search::class]);
+        self::assertChildren($query, self::FIELD_NAME_FILTERS, $children[Filter::class]);
+        self::assertChildren($query, self::FIELD_NAME_AGGREGATIONS, $children[Aggregation::class]);
     }
 
     public function testCreateWithOnlyInvalid(): void
@@ -156,16 +157,16 @@ final class QueryTest extends TestCase
     {
         $query = Query::create();
 
-        $this->assertChildren($query, self::FIELD_NAME_SEARCHES, []);
-        $this->assertChildren($query, self::FIELD_NAME_FILTERS, []);
-        $this->assertChildren($query, self::FIELD_NAME_AGGREGATIONS, []);
+        self::assertChildren($query, self::FIELD_NAME_SEARCHES, []);
+        self::assertChildren($query, self::FIELD_NAME_FILTERS, []);
+        self::assertChildren($query, self::FIELD_NAME_AGGREGATIONS, []);
 
         $search = Search::create(['field'], 'value');
         $query->search($search);
 
-        $this->assertChildren($query, self::FIELD_NAME_SEARCHES, [$search]);
-        $this->assertChildren($query, self::FIELD_NAME_FILTERS, []);
-        $this->assertChildren($query, self::FIELD_NAME_AGGREGATIONS, []);
+        self::assertChildren($query, self::FIELD_NAME_SEARCHES, [$search]);
+        self::assertChildren($query, self::FIELD_NAME_FILTERS, []);
+        self::assertChildren($query, self::FIELD_NAME_AGGREGATIONS, []);
     }
 
     public function testSearchWithInvalidCriteria(): void
@@ -187,54 +188,54 @@ final class QueryTest extends TestCase
     {
         $query = Query::create();
 
-        $this->assertChildren($query, self::FIELD_NAME_SEARCHES, []);
-        $this->assertChildren($query, self::FIELD_NAME_FILTERS, []);
-        $this->assertChildren($query, self::FIELD_NAME_AGGREGATIONS, []);
+        self::assertChildren($query, self::FIELD_NAME_SEARCHES, []);
+        self::assertChildren($query, self::FIELD_NAME_FILTERS, []);
+        self::assertChildren($query, self::FIELD_NAME_AGGREGATIONS, []);
 
         $filter = Filter::create('field', 'value');
         $query->where($filter);
 
-        $this->assertChildren($query, self::FIELD_NAME_SEARCHES, []);
-        $this->assertChildren($query, self::FIELD_NAME_FILTERS, [$filter]);
-        $this->assertChildren($query, self::FIELD_NAME_AGGREGATIONS, []);
+        self::assertChildren($query, self::FIELD_NAME_SEARCHES, []);
+        self::assertChildren($query, self::FIELD_NAME_FILTERS, [$filter]);
+        self::assertChildren($query, self::FIELD_NAME_AGGREGATIONS, []);
     }
 
     public function testAggregate(): void
     {
         $query = Query::create();
 
-        $this->assertChildren($query, self::FIELD_NAME_SEARCHES, []);
-        $this->assertChildren($query, self::FIELD_NAME_FILTERS, []);
-        $this->assertChildren($query, self::FIELD_NAME_AGGREGATIONS, []);
+        self::assertChildren($query, self::FIELD_NAME_SEARCHES, []);
+        self::assertChildren($query, self::FIELD_NAME_FILTERS, []);
+        self::assertChildren($query, self::FIELD_NAME_AGGREGATIONS, []);
 
         $aggregation = Aggregation::create('field', Metric::SUM);
         $query->aggregate($aggregation);
 
-        $this->assertChildren($query, self::FIELD_NAME_SEARCHES, []);
-        $this->assertChildren($query, self::FIELD_NAME_FILTERS, []);
-        $this->assertChildren($query, self::FIELD_NAME_AGGREGATIONS, [$aggregation]);
+        self::assertChildren($query, self::FIELD_NAME_SEARCHES, []);
+        self::assertChildren($query, self::FIELD_NAME_FILTERS, []);
+        self::assertChildren($query, self::FIELD_NAME_AGGREGATIONS, [$aggregation]);
     }
 
     public function testMinScore(): void
     {
         $query = Query::create();
 
-        $this->assertNull($query->getOption(Query::OPTION_MIN_SCORE));
+        self::assertNull($query->getOption(Query::OPTION_MIN_SCORE));
 
         $query->setMinScore(42);
 
-        $this->assertEquals(42, $query->getOption(Query::OPTION_MIN_SCORE));
+        self::assertEquals(42, $query->getOption(Query::OPTION_MIN_SCORE));
     }
 
     public function testSearchOperator(): void
     {
         $query = Query::create();
 
-        $this->assertEquals(Should::OPERATOR, $query->getSearchOperator());
+        self::assertEquals(Should::OPERATOR, $query->getSearchOperator());
 
         $query->setSearchOperator(Must::OPERATOR);
 
-        $this->assertEquals(Must::OPERATOR, $query->getSearchOperator());
+        self::assertEquals(Must::OPERATOR, $query->getSearchOperator());
     }
 
     public function testSetInvalidSearchOperator(): void
@@ -254,7 +255,7 @@ final class QueryTest extends TestCase
             ->skip(1)
             ->limit(10);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'query'   => ['bool' => ['filter' => ['bool' => ['must' => [['term' => ['field' => 'value']]]]]]],
                 '_source' => ['field_a'],
@@ -268,10 +269,10 @@ final class QueryTest extends TestCase
         );
     }
 
-    /** @dataProvider toArrayDataProvider */
+    #[DataProvider('toArrayDataProvider')]
     public function testToArray(Query $query, array $expected): void
     {
-        $this->assertEquals($expected, $query->toArray());
+        self::assertEquals($expected, $query->toArray());
     }
 
     public static function toArrayDataProvider(): array
@@ -286,23 +287,23 @@ final class QueryTest extends TestCase
     private static function toArrayBatch1(): array
     {
         return [
-            'empty'                                  => [
+            'empty'                                     => [
                 'query'    => Query::create(),
                 'expected' => [],
             ],
-            'with a min_score'                       => [
+            'with_a_min_score'                          => [
                 'query'    => Query::create()->setMinScore(42),
                 'expected' => [
                     'min_score' => 42,
                 ],
             ],
-            'with a filter'                          => [
+            'with_a_filter'                             => [
                 'query'    => Query::create(Filter::create('field', 'value')),
                 'expected' => [
                     'query' => ['bool' => ['filter' => ['bool' => ['must' => [['term' => ['field' => 'value']]]]]]],
                 ],
             ],
-            'with a search, default search operator' => [
+            'with_a_search_and_default_search_operator' => [
                 'query'    => Query::create(Search::create(['field_a'], 'foo')),
                 'expected' => [
                     'query' => [
@@ -319,7 +320,7 @@ final class QueryTest extends TestCase
     private static function toArrayBatch2(): array
     {
         return [
-            'with two searches, AND connected'                      => [
+            'with_two_searches_connected_by_and'                    => [
                 'query'    => Query::create(
                     Search::create(['field_a'], 'foo'),
                     Search::create(['field_b'], 'bar')
@@ -335,7 +336,7 @@ final class QueryTest extends TestCase
                     ],
                 ],
             ],
-            'with an aggregation'                                   => [
+            'with_an_aggregation'                                   => [
                 'query'    => Query::create(Aggregation::create('field_a', Metric::SUM, 'my_agg')),
                 'expected' => [
                     'aggs' => [
@@ -345,7 +346,7 @@ final class QueryTest extends TestCase
                     ],
                 ],
             ],
-            'with a little bit of everything'                       => [
+            'with_a_little_bit_of_everything'                       => [
                 'query'    => Query::create(
                     Filter::create('field', 'value'),
                     Search::create(['field_a'], 'foo'),
@@ -369,7 +370,7 @@ final class QueryTest extends TestCase
                     'min_score' => 42,
                 ],
             ],
-            'advanced full text queries combined with bool queries' => [
+            'advanced_full_text_queries_combined_with_bool_queries' => [
                 'query'    => Query::create(
                     Filter::create('field', 'value')
                 )
@@ -440,7 +441,7 @@ final class QueryTest extends TestCase
     private static function toArrayBatch3(): array
     {
         return [
-            'basic nested query as filter' => [
+            'basic_nested_query_as_filter' => [
                 'query'    => Query::create(
                     Query::createNested('my_field', Filter::create('my_field.subfield', 'foobar'))
                 ),
@@ -477,7 +478,7 @@ final class QueryTest extends TestCase
                     ],
                 ],
             ],
-            'basic nested query as search' => [
+            'basic_nested_query_as_search' => [
                 'query'    => Query::create()
                     ->search(Query::createNested('my_field', Filter::create('my_field.subfield', 'foobar'))),
                 'expected' => [
@@ -510,7 +511,7 @@ final class QueryTest extends TestCase
                     ],
                 ],
             ],
-            'nested query with options'    => [
+            'nested_query_with_options'    => [
                 'query'    => Query::create(
                     Query::createNested('my_field', Filter::create('my_field.subfield', 'foobar'))
                         ->setOption(NestableQueryInterface::OPTION_SCORE_MODE, 'max')
@@ -554,16 +555,13 @@ final class QueryTest extends TestCase
         ];
     }
 
-    private function getPublicReflectionProperty(Query $query, string $fieldName): ReflectionProperty
+    private static function getPublicReflectionProperty(Query $query, string $fieldName): ReflectionProperty
     {
-        $property = new ReflectionProperty($query, $fieldName);
-        $property->setAccessible(true);
-
-        return $property;
+        return new ReflectionProperty($query, $fieldName);
     }
 
-    private function assertChildren(Query $query, string $fieldName, array $expected): void
+    private static function assertChildren(Query $query, string $fieldName, array $expected): void
     {
-        $this->assertEquals($expected, $this->getPublicReflectionProperty($query, $fieldName)->getValue($query));
+        self::assertEquals($expected, self::getPublicReflectionProperty($query, $fieldName)->getValue($query));
     }
 }

--- a/tests/Query/RawQueryTest.php
+++ b/tests/Query/RawQueryTest.php
@@ -5,16 +5,17 @@ namespace Kununu\Elasticsearch\Tests\Query;
 
 use Kununu\Elasticsearch\Query\RawQuery;
 use Kununu\Elasticsearch\Query\SortOrder;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class RawQueryTest extends TestCase
 {
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testCreate(array $rawQuery): void
     {
         $query = RawQuery::create($rawQuery);
 
-        $this->assertEquals($rawQuery, $query->toArray());
+        self::assertEquals($rawQuery, $query->toArray());
     }
 
     public static function createDataProvider(): array
@@ -23,7 +24,7 @@ final class RawQueryTest extends TestCase
             'empty'     => [
                 'rawQuery' => [],
             ],
-            'non-empty' => [
+            'non_empty' => [
                 'rawQuery' => ['query' => ['term' => ['field' => 'value']]],
             ],
         ];
@@ -37,7 +38,7 @@ final class RawQueryTest extends TestCase
             ->skip(1)
             ->limit(10);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'query'   => ['term' => ['field' => 'value']],
                 '_source' => ['field_a'],

--- a/tests/Repository/AbstractRepositoryTestCase.php
+++ b/tests/Repository/AbstractRepositoryTestCase.php
@@ -151,8 +151,8 @@ abstract class AbstractRepositoryTestCase extends TestCase
                                 '_index'  => self::INDEX['read'],
                                 '_score'  => 77,
                                 '_source' => [
-                                    'second'         => 'result',
-                                    'with_more_than' => 'one field',
+                                    'second'       => 'result',
+                                    'withMoreThan' => 'one field',
                                 ],
                             ],
                         ],
@@ -170,8 +170,8 @@ abstract class AbstractRepositoryTestCase extends TestCase
                         '_index'  => self::INDEX['read'],
                         '_score'  => 77,
                         '_source' => [
-                            'second'         => 'result',
-                            'with_more_than' => 'one field',
+                            'second'       => 'result',
+                            'withMoreThan' => 'one field',
                         ],
                     ],
                 ],

--- a/tests/Repository/EntitySerializerStub.php
+++ b/tests/Repository/EntitySerializerStub.php
@@ -5,7 +5,7 @@ namespace Kununu\Elasticsearch\Tests\Repository;
 
 use Kununu\Elasticsearch\Repository\EntitySerializerInterface;
 
-class EntitySerializerStub implements EntitySerializerInterface
+final class EntitySerializerStub implements EntitySerializerInterface
 {
     public function toElastic(mixed $entity): array
     {

--- a/tests/Repository/PersistableEntityStub.php
+++ b/tests/Repository/PersistableEntityStub.php
@@ -7,6 +7,10 @@ use Kununu\Elasticsearch\Repository\PersistableEntityInterface;
 
 final class PersistableEntityStub implements PersistableEntityInterface
 {
+    public array $_meta;
+    public mixed $property_a;
+    public mixed $property_b;
+
     public function toElastic(): array
     {
         return (array) $this;

--- a/tests/Repository/PersistableEntityStub.php
+++ b/tests/Repository/PersistableEntityStub.php
@@ -10,6 +10,9 @@ final class PersistableEntityStub implements PersistableEntityInterface
     public array $_meta;
     public mixed $property_a;
     public mixed $property_b;
+    public mixed $foo;
+    public mixed $second;
+    public mixed $withMoreThan;
 
     public function toElastic(): array
     {

--- a/tests/Repository/RepositoryAggregateByQueryTest.php
+++ b/tests/Repository/RepositoryAggregateByQueryTest.php
@@ -9,14 +9,15 @@ use Kununu\Elasticsearch\Query\Aggregation;
 use Kununu\Elasticsearch\Query\Criteria\Filter;
 use Kununu\Elasticsearch\Query\Query;
 use Kununu\Elasticsearch\Query\QueryInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class RepositoryAggregateByQueryTest extends AbstractRepositoryTestCase
 {
-    /** @dataProvider queryAndSearchResultDataProvider */
+    #[DataProvider('queryAndSearchResultDataProvider')]
     public function testAggregateByQuery(QueryInterface $query, array $esResult): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('search')
             ->with([
                 'index' => self::INDEX['read'],
@@ -26,25 +27,25 @@ final class RepositoryAggregateByQueryTest extends AbstractRepositoryTestCase
 
         $aggregationResult = $this->getRepository()->aggregateByQuery($query);
 
-        $this->assertEquals(count($esResult['hits']['hits']), $aggregationResult->getDocuments()->getCount());
-        $this->assertEquals(self::DOCUMENT_COUNT, $aggregationResult->getDocuments()->getTotal());
-        $this->assertCount(count($esResult['hits']['hits']), $aggregationResult->getDocuments());
-        $this->assertNull($aggregationResult->getDocuments()->getScrollId());
-        $this->assertEquals($esResult['hits']['hits'], $aggregationResult->getDocuments()->asArray());
+        self::assertEquals(count($esResult['hits']['hits']), $aggregationResult->getDocuments()->getCount());
+        self::assertEquals(self::DOCUMENT_COUNT, $aggregationResult->getDocuments()->getTotal());
+        self::assertCount(count($esResult['hits']['hits']), $aggregationResult->getDocuments());
+        self::assertNull($aggregationResult->getDocuments()->getScrollId());
+        self::assertEquals($esResult['hits']['hits'], $aggregationResult->getDocuments()->asArray());
 
-        $this->assertCount(1, $aggregationResult->getResults());
-        $this->assertEquals('my_aggregation', $aggregationResult->getResultByName('my_aggregation')->getName());
-        $this->assertEquals(0.1, $aggregationResult->getResultByName('my_aggregation')->getValue());
+        self::assertCount(1, $aggregationResult->getResults());
+        self::assertEquals('my_aggregation', $aggregationResult->getResultByName('my_aggregation')->getName());
+        self::assertEquals(0.1, $aggregationResult->getResultByName('my_aggregation')->getValue());
     }
 
-    /** @dataProvider queryAndSearchResultWithEntitiesDataProvider */
+    #[DataProvider('queryAndSearchResultWithEntitiesDataProvider')]
     public function testAggregateByQueryWithEntityFactory(
         QueryInterface $query,
         array $esResult,
         mixed $endResult
     ): void {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('search')
             ->with([
                 'index' => self::INDEX['read'],
@@ -53,34 +54,34 @@ final class RepositoryAggregateByQueryTest extends AbstractRepositoryTestCase
             ->willReturn(array_merge($esResult, ['aggregations' => ['my_aggregation' => ['value' => 0.1]]]));
 
         $aggregationResult = $this
-            ->getRepository(['entity_factory' => $this->getEntityFactory()])
+            ->getRepository(['entity_factory' => new EntityFactoryStub()])
             ->aggregateByQuery($query);
 
-        $this->assertEquals(count($esResult['hits']['hits']), $aggregationResult->getDocuments()->getCount());
-        $this->assertEquals(self::DOCUMENT_COUNT, $aggregationResult->getDocuments()->getTotal());
-        $this->assertCount(count($esResult['hits']['hits']), $aggregationResult->getDocuments());
-        $this->assertNull($aggregationResult->getDocuments()->getScrollId());
-        $this->assertEquals($endResult, $aggregationResult->getDocuments()->asArray());
+        self::assertEquals(count($esResult['hits']['hits']), $aggregationResult->getDocuments()->getCount());
+        self::assertEquals(self::DOCUMENT_COUNT, $aggregationResult->getDocuments()->getTotal());
+        self::assertCount(count($esResult['hits']['hits']), $aggregationResult->getDocuments());
+        self::assertNull($aggregationResult->getDocuments()->getScrollId());
+        self::assertEquals($endResult, $aggregationResult->getDocuments()->asArray());
 
         if (!empty($aggregationResult->getDocuments())) {
             foreach ($aggregationResult->getDocuments() as $entity) {
-                $this->assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
+                self::assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
             }
         }
 
-        $this->assertCount(1, $aggregationResult->getResults());
-        $this->assertEquals('my_aggregation', $aggregationResult->getResultByName('my_aggregation')->getName());
-        $this->assertEquals(0.1, $aggregationResult->getResultByName('my_aggregation')->getValue());
+        self::assertCount(1, $aggregationResult->getResults());
+        self::assertEquals('my_aggregation', $aggregationResult->getResultByName('my_aggregation')->getName());
+        self::assertEquals(0.1, $aggregationResult->getResultByName('my_aggregation')->getValue());
     }
 
-    /** @dataProvider queryAndSearchResultWithEntitiesDataProvider */
+    #[DataProvider('queryAndSearchResultWithEntitiesDataProvider')]
     public function testAggregateByQueryWithEntityClass(
         QueryInterface $query,
         array $esResult,
         mixed $endResult
     ): void {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('search')
             ->with([
                 'index' => self::INDEX['read'],
@@ -89,24 +90,24 @@ final class RepositoryAggregateByQueryTest extends AbstractRepositoryTestCase
             ->willReturn(array_merge($esResult, ['aggregations' => ['my_aggregation' => ['value' => 0.1]]]));
 
         $aggregationResult = $this
-            ->getRepository(['entity_class' => $this->getEntityClass()])
+            ->getRepository(['entity_class' => PersistableEntityStub::class])
             ->aggregateByQuery($query);
 
-        $this->assertEquals(count($esResult['hits']['hits']), $aggregationResult->getDocuments()->getCount());
-        $this->assertEquals(self::DOCUMENT_COUNT, $aggregationResult->getDocuments()->getTotal());
-        $this->assertCount(count($esResult['hits']['hits']), $aggregationResult->getDocuments());
-        $this->assertNull($aggregationResult->getDocuments()->getScrollId());
-        $this->assertEquals($endResult, $aggregationResult->getDocuments()->asArray());
+        self::assertEquals(count($esResult['hits']['hits']), $aggregationResult->getDocuments()->getCount());
+        self::assertEquals(self::DOCUMENT_COUNT, $aggregationResult->getDocuments()->getTotal());
+        self::assertCount(count($esResult['hits']['hits']), $aggregationResult->getDocuments());
+        self::assertNull($aggregationResult->getDocuments()->getScrollId());
+        self::assertEquals($endResult, $aggregationResult->getDocuments()->asArray());
 
         if (!empty($aggregationResult->getDocuments())) {
             foreach ($aggregationResult->getDocuments() as $entity) {
-                $this->assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
+                self::assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
             }
         }
 
-        $this->assertCount(1, $aggregationResult->getResults());
-        $this->assertEquals('my_aggregation', $aggregationResult->getResultByName('my_aggregation')->getName());
-        $this->assertEquals(0.1, $aggregationResult->getResultByName('my_aggregation')->getValue());
+        self::assertCount(1, $aggregationResult->getResults());
+        self::assertEquals('my_aggregation', $aggregationResult->getResultByName('my_aggregation')->getName());
+        self::assertEquals(0.1, $aggregationResult->getResultByName('my_aggregation')->getValue());
     }
 
     public function testAggregateByQueryFails(): void
@@ -117,7 +118,7 @@ final class RepositoryAggregateByQueryTest extends AbstractRepositoryTestCase
         );
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('search')
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
@@ -128,9 +129,9 @@ final class RepositoryAggregateByQueryTest extends AbstractRepositoryTestCase
         try {
             $this->getRepository()->aggregateByQuery($query);
         } catch (ReadOperationException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertNull($e->getQuery());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertNull($e->getQuery());
         }
     }
 }

--- a/tests/Repository/RepositoryClearScrollIdTest.php
+++ b/tests/Repository/RepositoryClearScrollIdTest.php
@@ -13,7 +13,7 @@ final class RepositoryClearScrollIdTest extends AbstractRepositoryTestCase
         $scrollId = 'foobar';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('clearScroll')
             ->with([
                 'body' => [
@@ -22,7 +22,7 @@ final class RepositoryClearScrollIdTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository()->clearScrollId($scrollId);
@@ -33,7 +33,7 @@ final class RepositoryClearScrollIdTest extends AbstractRepositoryTestCase
         $scrollId = 'foobar';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('clearScroll')
             ->with([
                 'body' => [
@@ -43,7 +43,7 @@ final class RepositoryClearScrollIdTest extends AbstractRepositoryTestCase
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 self::ERROR_PREFIX . self::ERROR_MESSAGE
@@ -52,8 +52,8 @@ final class RepositoryClearScrollIdTest extends AbstractRepositoryTestCase
         try {
             $this->getRepository()->clearScrollId($scrollId);
         } catch (RepositoryException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
         }
     }
 }

--- a/tests/Repository/RepositoryConfigurationTest.php
+++ b/tests/Repository/RepositoryConfigurationTest.php
@@ -9,45 +9,46 @@ use Kununu\Elasticsearch\Repository\EntitySerializerInterface;
 use Kununu\Elasticsearch\Repository\OperationType;
 use Kununu\Elasticsearch\Repository\PersistableEntityInterface;
 use Kununu\Elasticsearch\Repository\RepositoryConfiguration;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use TypeError;
 
 final class RepositoryConfigurationTest extends TestCase
 {
-    /** @dataProvider inflateConfigDataProvider */
+    #[DataProvider('inflateConfigDataProvider')]
     public function testInflateConfig(array $input, string $expectedReadAlias, string $expectedWriteAlias): void
     {
         $config = new RepositoryConfiguration($input);
 
-        $this->assertEquals($expectedReadAlias, $config->getIndex(OperationType::READ));
-        $this->assertEquals($expectedWriteAlias, $config->getIndex(OperationType::WRITE));
+        self::assertEquals($expectedReadAlias, $config->getIndex(OperationType::READ));
+        self::assertEquals($expectedWriteAlias, $config->getIndex(OperationType::WRITE));
     }
 
     public static function inflateConfigDataProvider(): array
     {
         return [
-            'only index name given'                            => [
+            'only_index_name_given'                            => [
                 'input'                => ['index' => 'my_index'],
                 'expected_read_alias'  => 'my_index',
                 'expected_write_alias' => 'my_index',
             ],
-            'index name and read alias given'                  => [
+            'index_name_and_read_alias_given'                  => [
                 'input'                => ['index' => 'my_index', 'index_read' => 'my_index_read'],
                 'expected_read_alias'  => 'my_index_read',
                 'expected_write_alias' => 'my_index',
             ],
-            'index name and write alias given'                 => [
+            'index_name_and_write_alias_given'                 => [
                 'input'                => ['index' => 'my_index', 'index_write' => 'my_index_write'],
                 'expected_read_alias'  => 'my_index',
                 'expected_write_alias' => 'my_index_write',
             ],
-            'read and write alias given'                       => [
+            'read_and_write_alias_given'                       => [
                 'input'                => ['index_read' => 'my_index_read', 'index_write' => 'my_index_write'],
                 'expected_read_alias'  => 'my_index_read',
                 'expected_write_alias' => 'my_index_write',
             ],
-            'index name as well as read and write alias given' => [
+            'index_name_as_well_as_read_and_write_alias_given' => [
                 'input'                => [
                     'index'       => 'this_will_be_ignored',
                     'index_read'  => 'my_index_read',
@@ -59,7 +60,7 @@ final class RepositoryConfigurationTest extends TestCase
         ];
     }
 
-    /** @dataProvider noValidIndexConfiguredDataProvider */
+    #[DataProvider('noValidIndexConfiguredDataProvider')]
     public function testNoValidIndexConfigured(array $input, string $operationType, string $expectedExceptionMsg): void
     {
         $config = new RepositoryConfiguration($input);
@@ -73,19 +74,19 @@ final class RepositoryConfigurationTest extends TestCase
     public static function noValidIndexConfiguredDataProvider(): array
     {
         $cases = [
-            'nothing given'          => [
+            'nothing_given'          => [
                 'input' => [],
             ],
-            'empty index name given' => [
+            'empty_index_name_given' => [
                 'input' => ['index' => ''],
             ],
-            'empty aliases given'    => [
+            'empty_aliases_given'    => [
                 'input' => ['index_read' => '', 'index_write' => ''],
             ],
-            'null index name given'  => [
+            'null_index_name_given'  => [
                 'input' => ['index' => null],
             ],
-            'null aliases given'     => [
+            'null_aliases_given'     => [
                 'input' => ['index_read' => null, 'index_write' => null],
             ],
         ];
@@ -94,9 +95,11 @@ final class RepositoryConfigurationTest extends TestCase
         foreach ($cases as $name => $data) {
             foreach ([OperationType::READ, OperationType::WRITE] as $operationType) {
                 $data['operation_type'] = $operationType;
-                $data['expected_exception_msg'] =
-                    'No valid index name configured for operation "' . $operationType . '"';
-                $variations['operation type ' . $operationType . ' ' . $name] = $data;
+                $data['expected_exception_msg'] = sprintf(
+                    'No valid index name configured for operation "%s"',
+                    $operationType
+                );
+                $variations[sprintf('operation_type_%s_%s', $operationType, $name)] = $data;
             }
         }
 
@@ -114,7 +117,7 @@ final class RepositoryConfigurationTest extends TestCase
 
         $config = new RepositoryConfiguration(['entity_serializer' => $mySerializer]);
 
-        $this->assertEquals($mySerializer, $config->getEntitySerializer());
+        self::assertEquals($mySerializer, $config->getEntitySerializer());
     }
 
     public function testInvalidEntitySerializer(): void
@@ -123,7 +126,7 @@ final class RepositoryConfigurationTest extends TestCase
 
         $this->expectException(TypeError::class);
 
-        $this->assertNull(new RepositoryConfiguration(['entity_serializer' => $mySerializer]));
+        self::assertNull(new RepositoryConfiguration(['entity_serializer' => $mySerializer]));
     }
 
     public function testValidEntityFactory(): void
@@ -137,7 +140,7 @@ final class RepositoryConfigurationTest extends TestCase
 
         $config = new RepositoryConfiguration(['entity_factory' => $myFactory]);
 
-        $this->assertEquals($myFactory, $config->getEntityFactory());
+        self::assertEquals($myFactory, $config->getEntityFactory());
     }
 
     public function testInvalidEntityFactory(): void
@@ -146,7 +149,7 @@ final class RepositoryConfigurationTest extends TestCase
 
         $this->expectException(TypeError::class);
 
-        $this->assertNull(new RepositoryConfiguration(['entity_factory' => $myFactory]));
+        self::assertNull(new RepositoryConfiguration(['entity_factory' => $myFactory]));
     }
 
     public function testValidEntityClass(): void
@@ -178,7 +181,7 @@ final class RepositoryConfigurationTest extends TestCase
             )
         );
 
-        $this->assertNull(new RepositoryConfiguration(['entity_class' => stdClass::class]));
+        self::assertNull(new RepositoryConfiguration(['entity_class' => stdClass::class]));
     }
 
     public function testNonExistentEntityClass(): void
@@ -188,62 +191,62 @@ final class RepositoryConfigurationTest extends TestCase
             'Given entity class does not exist.'
         );
 
-        $this->assertNull(new RepositoryConfiguration(['entity_class' => '\Foo\Bar']));
+        self::assertNull(new RepositoryConfiguration(['entity_class' => '\Foo\Bar']));
     }
 
-    /** @dataProvider forceRefreshOnWriteDataProvider */
+    #[DataProvider('forceRefreshOnWriteDataProvider')]
     public function testForceRefreshOnWrite(array $input, bool $expected): void
     {
         $config = new RepositoryConfiguration($input);
 
-        $this->assertSame($expected, $config->getForceRefreshOnWrite());
+        self::assertSame($expected, $config->getForceRefreshOnWrite());
     }
 
     public static function forceRefreshOnWriteDataProvider(): array
     {
         return [
-            'param not given'                               => [
+            'param_not_given'                               => [
                 'input'    => [
                     'index' => 'foobar',
                 ],
                 'expected' => false,
             ],
-            'false given'                                   => [
+            'false_given'                                   => [
                 'input'    => [
                     'index'                  => 'foobar',
                     'force_refresh_on_write' => false,
                 ],
                 'expected' => false,
             ],
-            'falsy value given'                             => [
+            'falsy_value_given'                             => [
                 'input'    => [
                     'index'                  => 'foobar',
                     'force_refresh_on_write' => 0,
                 ],
                 'expected' => false,
             ],
-            'true given'                                    => [
+            'true_given'                                    => [
                 'input'    => [
                     'index'                  => 'foobar',
                     'force_refresh_on_write' => true,
                 ],
                 'expected' => true,
             ],
-            'true-ish integer given'                        => [
+            'true-ish_integer_given'                        => [
                 'input'    => [
                     'index'                  => 'foobar',
                     'force_refresh_on_write' => 1,
                 ],
                 'expected' => true,
             ],
-            'true-ish string given'                         => [
+            'true-ish_string_given'                         => [
                 'input'    => [
                     'index'                  => 'foobar',
                     'force_refresh_on_write' => 'yes',
                 ],
                 'expected' => true,
             ],
-            'not-so-clever-but-still-true-ish string given' => [
+            'not-so-clever-but-still-true-ish_string_given' => [
                 'input'    => [
                     'index'                  => 'foobar',
                     'force_refresh_on_write' => 'no',
@@ -253,59 +256,59 @@ final class RepositoryConfigurationTest extends TestCase
         ];
     }
 
-    /** @dataProvider trackTotalHitsDataProvider */
+    #[DataProvider('trackTotalHitsDataProvider')]
     public function testTrackTotalHits(array $input, ?bool $expected): void
     {
         $config = new RepositoryConfiguration($input);
 
-        $this->assertSame($expected, $config->getTrackTotalHits());
+        self::assertSame($expected, $config->getTrackTotalHits());
     }
 
     public static function trackTotalHitsDataProvider(): array
     {
         return [
-            'param not given'                               => [
+            'param_not_given'                               => [
                 'input'    => [
                     'index' => 'foobar',
                 ],
                 'expected' => null,
             ],
-            'false given'                                   => [
+            'false_given'                                   => [
                 'input'    => [
                     'index'            => 'foobar',
                     'track_total_hits' => false,
                 ],
                 'expected' => false,
             ],
-            'falsy value given'                             => [
+            'falsy_value_given'                             => [
                 'input'    => [
                     'index'            => 'foobar',
                     'track_total_hits' => 0,
                 ],
                 'expected' => false,
             ],
-            'true given'                                    => [
+            'true_given'                                    => [
                 'input'    => [
                     'index'            => 'foobar',
                     'track_total_hits' => true,
                 ],
                 'expected' => true,
             ],
-            'true-ish integer given'                        => [
+            'true-ish_integer_given'                        => [
                 'input'    => [
                     'index'            => 'foobar',
                     'track_total_hits' => 1,
                 ],
                 'expected' => true,
             ],
-            'true-ish string given'                         => [
+            'true-ish_string_given'                         => [
                 'input'    => [
                     'index'            => 'foobar',
                     'track_total_hits' => 'yes',
                 ],
                 'expected' => true,
             ],
-            'not-so-clever-but-still-true-ish string given' => [
+            'not-so-clever-but-still-true-ish_string_given' => [
                 'input'    => [
                     'index'            => 'foobar',
                     'track_total_hits' => 'no',
@@ -315,24 +318,24 @@ final class RepositoryConfigurationTest extends TestCase
         ];
     }
 
-    /** @dataProvider scrollContextKeepaliveDataProvider */
+    #[DataProvider('scrollContextKeepaliveDataProvider')]
     public function testScrollContextKeepalive(array $input, string $expected): void
     {
         $config = new RepositoryConfiguration($input);
 
-        $this->assertSame($expected, $config->getScrollContextKeepalive());
+        self::assertSame($expected, $config->getScrollContextKeepalive());
     }
 
     public static function scrollContextKeepaliveDataProvider(): array
     {
         return [
-            'param not given'       => [
+            'param_not_given'       => [
                 'input'    => [
                     'index' => 'foobar',
                 ],
                 'expected' => '1m', // the default
             ],
-            'valid time unit given' => [
+            'valid_time_unit_given' => [
                 'input'    => [
                     'index'                    => 'foobar',
                     'scroll_context_keepalive' => '10m',
@@ -349,14 +352,14 @@ final class RepositoryConfigurationTest extends TestCase
             'Invalid value for scroll_context_keepalive given. Must be a valid time unit.'
         );
 
-        $this->assertNull(new RepositoryConfiguration(['index' => 'foobar', 'scroll_context_keepalive' => 'xxx']));
+        self::assertNull(new RepositoryConfiguration(['index' => 'foobar', 'scroll_context_keepalive' => 'xxx']));
     }
 
     public function testGetDefaultScrollContextKeepalive(): void
     {
         $config = new RepositoryConfiguration([]);
 
-        $this->assertSame('1m', $config->getScrollContextKeepalive());
-        $this->assertFalse($config->getForceRefreshOnWrite());
+        self::assertSame('1m', $config->getScrollContextKeepalive());
+        self::assertFalse($config->getForceRefreshOnWrite());
     }
 }

--- a/tests/Repository/RepositoryCountByQueryTest.php
+++ b/tests/Repository/RepositoryCountByQueryTest.php
@@ -7,14 +7,15 @@ use Exception;
 use Kununu\Elasticsearch\Exception\ReadOperationException;
 use Kununu\Elasticsearch\Query\Query;
 use Kununu\Elasticsearch\Query\QueryInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class RepositoryCountByQueryTest extends AbstractRepositoryTestCase
 {
-    /** @dataProvider queriesDataProvider */
+    #[DataProvider('queriesDataProvider')]
     public function testCountByQuery(QueryInterface $query): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('count')
             ->with([
                 'index' => self::INDEX['read'],
@@ -22,26 +23,27 @@ final class RepositoryCountByQueryTest extends AbstractRepositoryTestCase
             ])
             ->willReturn(['count' => self::DOCUMENT_COUNT]);
 
-        $this->assertEquals(self::DOCUMENT_COUNT, $this->getRepository()->countByQuery($query));
+        self::assertEquals(self::DOCUMENT_COUNT, $this->getRepository()->countByQuery($query));
     }
 
     public function testCountByQueryFails(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('count')
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
+            ->expects(self::once())
             ->method('error')
             ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
 
         try {
             $this->getRepository()->countByQuery(Query::create());
         } catch (ReadOperationException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertNull($e->getQuery());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertNull($e->getQuery());
         }
     }
 }

--- a/tests/Repository/RepositoryCountTest.php
+++ b/tests/Repository/RepositoryCountTest.php
@@ -14,7 +14,7 @@ final class RepositoryCountTest extends AbstractRepositoryTestCase
         $query = Query::create();
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('count')
             ->with([
                 'index' => self::INDEX['read'],
@@ -22,26 +22,27 @@ final class RepositoryCountTest extends AbstractRepositoryTestCase
             ])
             ->willReturn(['count' => self::DOCUMENT_COUNT]);
 
-        $this->assertEquals(self::DOCUMENT_COUNT, $this->getRepository()->count());
+        self::assertEquals(self::DOCUMENT_COUNT, $this->getRepository()->count());
     }
 
     public function testCountFails(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('count')
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
+            ->expects(self::once())
             ->method('error')
             ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
 
         try {
             $this->getRepository()->count();
         } catch (ReadOperationException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertNull($e->getQuery());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertNull($e->getQuery());
         }
     }
 }

--- a/tests/Repository/RepositoryDeleteBulkTest.php
+++ b/tests/Repository/RepositoryDeleteBulkTest.php
@@ -6,14 +6,13 @@ namespace Kununu\Elasticsearch\Tests\Repository;
 use Exception;
 use Kununu\Elasticsearch\Exception\BulkException;
 use Kununu\Elasticsearch\Repository\Repository;
-use PHPUnit\Framework\TestCase;
 
 final class RepositoryDeleteBulkTest extends AbstractRepositoryTestCase
 {
     public function testDeleteBulk(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bulk')
             ->with([
                 'index' => self::INDEX['write'],
@@ -32,7 +31,7 @@ final class RepositoryDeleteBulkTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository()->deleteBulk(self::ID, self::ID_2);
@@ -41,7 +40,7 @@ final class RepositoryDeleteBulkTest extends AbstractRepositoryTestCase
     public function testDeleteBulkWithForcedRefresh(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bulk')
             ->with([
                 'index'   => self::INDEX['write'],
@@ -61,7 +60,7 @@ final class RepositoryDeleteBulkTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository(['force_refresh_on_write' => true])->deleteBulk(self::ID, self::ID_2);
@@ -70,7 +69,7 @@ final class RepositoryDeleteBulkTest extends AbstractRepositoryTestCase
     public function testDeleteBulkFails(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bulk')
             ->with([
                 'index' => self::INDEX['write'],
@@ -90,22 +89,23 @@ final class RepositoryDeleteBulkTest extends AbstractRepositoryTestCase
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
+            ->expects(self::once())
             ->method('error')
             ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
 
         try {
             $this->getRepository()->deleteBulk(self::ID, self::ID_2);
         } catch (BulkException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertEquals($operations, $e->getOperations());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertEquals($operations, $e->getOperations());
         }
     }
 
     public function testPostDeleteBulkIsCalled(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bulk')
             ->with([
                 'index' => self::INDEX['write'],
@@ -124,15 +124,15 @@ final class RepositoryDeleteBulkTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $manager = new class($this->clientMock, ['index_write' => self::INDEX['write']]) extends Repository {
             protected function postDeleteBulk(string ...$ids): void
             {
-                TestCase::assertCount(2, $ids);
-                TestCase::assertEquals(AbstractRepositoryTestCase::ID, $ids[0]);
-                TestCase::assertEquals(AbstractRepositoryTestCase::ID_2, $ids[1]);
+                AbstractRepositoryTestCase::assertCount(2, $ids);
+                AbstractRepositoryTestCase::assertEquals(AbstractRepositoryTestCase::ID, $ids[0]);
+                AbstractRepositoryTestCase::assertEquals(AbstractRepositoryTestCase::ID_2, $ids[1]);
             }
         };
 
@@ -142,11 +142,11 @@ final class RepositoryDeleteBulkTest extends AbstractRepositoryTestCase
     public function testDeleteBulkWithoutIds(): void
     {
         $this->clientMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('bulk');
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository()->deleteBulk();

--- a/tests/Repository/RepositoryDeleteByQueryTest.php
+++ b/tests/Repository/RepositoryDeleteByQueryTest.php
@@ -15,7 +15,7 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
         $expectedResult = ['some_fake_es_response' => 'deletion was successful'];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteByQuery')
             ->with([
                 'index' => self::INDEX['write'],
@@ -40,7 +40,7 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
             ->willReturn($expectedResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $result = $this->getRepository()->deleteByQuery(
@@ -49,7 +49,7 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
             )
         );
 
-        $this->assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     public function testDeleteByQueryWithForcedRefresh(): void
@@ -57,7 +57,7 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
         $expectedResult = ['some_fake_es_response' => 'deletion was successful'];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteByQuery')
             ->with([
                 'index'   => self::INDEX['write'],
@@ -83,7 +83,7 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
             ->willReturn($expectedResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $result = $this->getRepository(['force_refresh_on_write' => true])->deleteByQuery(
@@ -92,7 +92,7 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
             )
         );
 
-        $this->assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     public function testDeleteByQueryWithProceedOnConflicts(): void
@@ -100,7 +100,7 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
         $expectedResult = ['some_fake_es_response' => 'deletion was successful'];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteByQuery')
             ->with([
                 'index'     => self::INDEX['write'],
@@ -126,7 +126,7 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
             ->willReturn($expectedResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $result = $this->getRepository()->deleteByQuery(
@@ -136,13 +136,13 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
             true
         );
 
-        $this->assertSame($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     public function testDeleteByQueryFails(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteByQuery')
             ->with([
                 'index' => self::INDEX['write'],
@@ -167,6 +167,7 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
+            ->expects(self::once())
             ->method('error')
             ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
 
@@ -177,8 +178,8 @@ final class RepositoryDeleteByQueryTest extends AbstractRepositoryTestCase
                 )
             );
         } catch (WriteOperationException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
         }
     }
 }

--- a/tests/Repository/RepositoryDeleteTest.php
+++ b/tests/Repository/RepositoryDeleteTest.php
@@ -8,14 +8,13 @@ use Exception;
 use Kununu\Elasticsearch\Exception\DeleteException;
 use Kununu\Elasticsearch\Exception\DocumentNotFoundException;
 use Kununu\Elasticsearch\Repository\Repository;
-use PHPUnit\Framework\TestCase;
 
 final class RepositoryDeleteTest extends AbstractRepositoryTestCase
 {
     public function testDelete(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('delete')
             ->with([
                 'index' => self::INDEX['write'],
@@ -23,7 +22,7 @@ final class RepositoryDeleteTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository()->delete(self::ID);
@@ -32,7 +31,7 @@ final class RepositoryDeleteTest extends AbstractRepositoryTestCase
     public function testDeleteWithForcedRefresh(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('delete')
             ->with([
                 'index'   => self::INDEX['write'],
@@ -41,7 +40,7 @@ final class RepositoryDeleteTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository(['force_refresh_on_write' => true])->delete(self::ID);
@@ -50,7 +49,7 @@ final class RepositoryDeleteTest extends AbstractRepositoryTestCase
     public function testDeleteFails(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('delete')
             ->with([
                 'index' => self::INDEX['write'],
@@ -65,16 +64,16 @@ final class RepositoryDeleteTest extends AbstractRepositoryTestCase
         try {
             $this->getRepository()->delete(self::ID);
         } catch (DeleteException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertEquals(self::ID, $e->getDocumentId());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertEquals(self::ID, $e->getDocumentId());
         }
     }
 
     public function testDeleteFailsBecauseDocumentNotFound(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('delete')
             ->with([
                 'index' => self::INDEX['write'],
@@ -83,22 +82,22 @@ final class RepositoryDeleteTest extends AbstractRepositoryTestCase
             ->willThrowException(new Missing404Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         try {
             $this->getRepository()->delete(self::ID);
         } catch (DocumentNotFoundException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . 'No document found with id ' . self::ID, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertEquals(self::ID, $e->getDocumentId());
+            self::assertEquals(self::ERROR_PREFIX . 'No document found with id ' . self::ID, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertEquals(self::ID, $e->getDocumentId());
         }
     }
 
     public function testPostDeleteIsCalled(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('delete')
             ->with([
                 'index' => self::INDEX['write'],
@@ -106,13 +105,13 @@ final class RepositoryDeleteTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $manager = new class($this->clientMock, ['index_write' => self::INDEX['write']]) extends Repository {
             protected function postDelete(string $id): void
             {
-                TestCase::assertEquals(AbstractRepositoryTestCase::ID, $id);
+                AbstractRepositoryTestCase::assertEquals(AbstractRepositoryTestCase::ID, $id);
             }
         };
 

--- a/tests/Repository/RepositoryFindByIdTest.php
+++ b/tests/Repository/RepositoryFindByIdTest.php
@@ -6,19 +6,20 @@ namespace Kununu\Elasticsearch\Tests\Repository;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use Exception;
 use Kununu\Elasticsearch\Exception\ReadOperationException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class RepositoryFindByIdTest extends AbstractRepositoryTestCase
 {
     public static function findByIdResultDataProvider(): array
     {
         return [
-            'no result'      => [
+            'no_result'      => [
                 'es_result'  => [
                     'found' => false,
                 ],
                 'end_result' => null,
             ],
-            'document found' => [
+            'document_found' => [
                 'es_result'  => [
                     '_index'   => self::INDEX['read'],
                     '_version' => 1,
@@ -63,11 +64,11 @@ final class RepositoryFindByIdTest extends AbstractRepositoryTestCase
         );
     }
 
-    /** @dataProvider findByIdResultDataProvider */
+    #[DataProvider('findByIdResultDataProvider')]
     public function testFindById(array $esResult, mixed $endResult): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with([
                 'index' => self::INDEX['read'],
@@ -76,17 +77,17 @@ final class RepositoryFindByIdTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->assertEquals($endResult, $this->getRepository()->findById(self::ID));
+        self::assertEquals($endResult, $this->getRepository()->findById(self::ID));
     }
 
-    /** @dataProvider findByIdResultDataProvider */
+    #[DataProvider('findByIdResultDataProvider')]
     public function testFindByIdTrackingTotalHits(array $esResult, mixed $endResult): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with([
                 'index'            => self::INDEX['read'],
@@ -96,17 +97,17 @@ final class RepositoryFindByIdTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->assertEquals($endResult, $this->getRepository(['track_total_hits' => true])->findById(self::ID));
+        self::assertEquals($endResult, $this->getRepository(['track_total_hits' => true])->findById(self::ID));
     }
 
-    /** @dataProvider findByIdResultDataProvider */
+    #[DataProvider('findByIdResultDataProvider')]
     public function testFindByIdWithSourceField(array $esResult, mixed $endResult): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with([
                 'index'   => self::INDEX['read'],
@@ -116,17 +117,17 @@ final class RepositoryFindByIdTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->assertEquals($endResult, $this->getRepository()->findById(self::ID, ['foo', 'foo2']));
+        self::assertEquals($endResult, $this->getRepository()->findById(self::ID, ['foo', 'foo2']));
     }
 
-    /** @dataProvider findByIdResultWithEntitiesDataProvider */
+    #[DataProvider('findByIdResultWithEntitiesDataProvider')]
     public function testFindByIdWithEntityClass(array $esResult, mixed $endResult): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with([
                 'index' => self::INDEX['read'],
@@ -135,27 +136,27 @@ final class RepositoryFindByIdTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $result = $this
-            ->getRepository(['entity_class' => $this->getEntityClass()])
+            ->getRepository(['entity_class' => PersistableEntityStub::class])
             ->findById(self::ID);
 
-        $this->assertEquals($endResult, $result);
+        self::assertEquals($endResult, $result);
         if ($endResult) {
-            $this->assertEquals(
+            self::assertEquals(
                 ['_index' => self::INDEX['read'], '_version' => 1, 'found' => true],
                 $result->_meta
             );
         }
     }
 
-    /** @dataProvider findByIdResultWithEntitiesDataProvider */
+    #[DataProvider('findByIdResultWithEntitiesDataProvider')]
     public function testFindByIdWithEntityFactory(array $esResult, mixed $endResult): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with([
                 'index' => self::INDEX['read'],
@@ -164,16 +165,16 @@ final class RepositoryFindByIdTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $result = $this
-            ->getRepository(['entity_factory' => $this->getEntityFactory()])
+            ->getRepository(['entity_factory' => new EntityFactoryStub()])
             ->findById(self::ID);
 
-        $this->assertEquals($endResult, $result);
+        self::assertEquals($endResult, $result);
         if ($endResult) {
-            $this->assertEquals(
+            self::assertEquals(
                 ['_index' => self::INDEX['read'], '_version' => 1, 'found' => true],
                 $result->_meta
             );
@@ -183,7 +184,7 @@ final class RepositoryFindByIdTest extends AbstractRepositoryTestCase
     public function testFindByIdFails(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with([
                 'index' => self::INDEX['read'],
@@ -198,16 +199,16 @@ final class RepositoryFindByIdTest extends AbstractRepositoryTestCase
         try {
             $this->getRepository()->findById(self::ID);
         } catch (ReadOperationException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertNull($e->getQuery());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertNull($e->getQuery());
         }
     }
 
     public function testFindByIdFailsWith404(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with([
                 'index' => self::INDEX['read'],
@@ -215,6 +216,6 @@ final class RepositoryFindByIdTest extends AbstractRepositoryTestCase
             ])
             ->willThrowException(new Missing404Exception());
 
-        $this->assertNull($this->getRepository()->findById(self::ID));
+        self::assertNull($this->getRepository()->findById(self::ID));
     }
 }

--- a/tests/Repository/RepositoryFindByIdsTest.php
+++ b/tests/Repository/RepositoryFindByIdsTest.php
@@ -5,6 +5,7 @@ namespace Kununu\Elasticsearch\Tests\Repository;
 
 use Exception;
 use Kununu\Elasticsearch\Exception\ReadOperationException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
 {
@@ -134,11 +135,11 @@ final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
         );
     }
 
-    /** @dataProvider findByIdsResultDataProvider */
+    #[DataProvider('findByIdsResultDataProvider')]
     public function testFindByIds(array $esResult, mixed $endResult): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('mget')
             ->with([
                 'index' => self::INDEX['read'],
@@ -156,21 +157,21 @@ final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('critical');
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->assertEquals($endResult, $this->getRepository()->findByIds([self::ID, self::ID_2]));
+        self::assertEquals($endResult, $this->getRepository()->findByIds([self::ID, self::ID_2]));
     }
 
-    /** @dataProvider findByIdsResultDataProvider */
+    #[DataProvider('findByIdsResultDataProvider')]
     public function testFindByIdsWithSourceField(array $esResult, mixed $endResult): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('mget')
             ->with([
                 'index' => self::INDEX['read'],
@@ -190,21 +191,21 @@ final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('critical');
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->assertEquals($endResult, $this->getRepository()->findByIds([self::ID, self::ID_2], ['foo', 'foo2']));
+        self::assertEquals($endResult, $this->getRepository()->findByIds([self::ID, self::ID_2], ['foo', 'foo2']));
     }
 
-    /** @dataProvider findByIdsResultWithEntitiesDataProvider */
+    #[DataProvider('findByIdsResultWithEntitiesDataProvider')]
     public function testFindByIdWithEntityClass(array $esResult, mixed $endResult): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('mget')
             ->with([
                 'index' => self::INDEX['read'],
@@ -222,21 +223,21 @@ final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('critical');
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $results = $this
-            ->getRepository(['entity_class' => $this->getEntityClass()])
+            ->getRepository(['entity_class' => PersistableEntityStub::class])
             ->findByIds([self::ID, self::ID_2]);
 
-        $this->assertEquals(array_values($endResult), $results);
+        self::assertEquals(array_values($endResult), $results);
         if (!empty($endResult)) {
             foreach ($endResult as $id => $result) {
-                $this->assertEquals(
+                self::assertEquals(
                     ['_index' => self::INDEX['read'], '_id' => $id, '_version' => 1, 'found' => true],
                     $result->_meta
                 );
@@ -244,11 +245,11 @@ final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
         }
     }
 
-    /** @dataProvider findByIdsResultWithEntitiesDataProvider */
+    #[DataProvider('findByIdsResultWithEntitiesDataProvider')]
     public function testFindByIdsWithEntityFactory(array $esResult, mixed $endResult): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('mget')
             ->with([
                 'index' => self::INDEX['read'],
@@ -266,21 +267,21 @@ final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('critical');
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $results = $this
-            ->getRepository(['entity_factory' => $this->getEntityFactory()])
+            ->getRepository(['entity_factory' => new EntityFactoryStub()])
             ->findByIds([self::ID, self::ID_2]);
 
-        $this->assertEquals(array_values($endResult), $results);
+        self::assertEquals(array_values($endResult), $results);
         if (!empty($endResult)) {
             foreach ($endResult as $id => $result) {
-                $this->assertEquals(
+                self::assertEquals(
                     ['_index' => self::INDEX['read'], '_id' => $id, '_version' => 1, 'found' => true],
                     $result->_meta
                 );
@@ -290,7 +291,7 @@ final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
 
     public function testFindByIdsWithoutIds(): void
     {
-        $this->assertEmpty($this->getRepository()->findByIds([]));
+        self::assertEmpty($this->getRepository()->findByIds([]));
     }
 
     public function testFindByIdsFails(): void
@@ -310,13 +311,13 @@ final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('mget')
             ->with($body)
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('critical')
             ->with(
                 'Elasticsearch request error',
@@ -324,7 +325,7 @@ final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
             );
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(
                 self::ERROR_PREFIX . self::ERROR_MESSAGE
@@ -333,9 +334,9 @@ final class RepositoryFindByIdsTest extends AbstractRepositoryTestCase
         try {
             $this->getRepository()->findByIds([self::ID, self::ID_2]);
         } catch (ReadOperationException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertNull($e->getQuery());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertNull($e->getQuery());
         }
     }
 }

--- a/tests/Repository/RepositoryFindByQueryTest.php
+++ b/tests/Repository/RepositoryFindByQueryTest.php
@@ -8,10 +8,11 @@ use Kununu\Elasticsearch\Exception\ReadOperationException;
 use Kununu\Elasticsearch\Query\Query;
 use Kununu\Elasticsearch\Query\QueryInterface;
 use Kununu\Elasticsearch\Repository\RepositoryConfiguration;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class RepositoryFindByQueryTest extends AbstractRepositoryTestCase
 {
-    /** @dataProvider queryAndSearchResultVariationsDataProvider */
+    #[DataProvider('queryAndSearchResultVariationsDataProvider')]
     public function testFindByQuery(QueryInterface $query, array $esResult, mixed $endResult, bool $scroll): void
     {
         $rawParams = [
@@ -24,7 +25,7 @@ final class RepositoryFindByQueryTest extends AbstractRepositoryTestCase
         }
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('search')
             ->with($rawParams)
             ->willReturn($esResult);
@@ -33,16 +34,16 @@ final class RepositoryFindByQueryTest extends AbstractRepositoryTestCase
             ? $this->getRepository()->findScrollableByQuery($query)
             : $this->getRepository()->findByQuery($query);
 
-        $this->assertEquals($endResult, $result->asArray());
-        $this->assertEquals(self::DOCUMENT_COUNT, $result->getTotal());
+        self::assertEquals($endResult, $result->asArray());
+        self::assertEquals(self::DOCUMENT_COUNT, $result->getTotal());
         if ($scroll) {
-            $this->assertEquals(self::SCROLL_ID, $result->getScrollId());
+            self::assertEquals(self::SCROLL_ID, $result->getScrollId());
         } else {
-            $this->assertNull($result->getScrollId());
+            self::assertNull($result->getScrollId());
         }
     }
 
-    /** @dataProvider queryAndSearchResultVariationsWithEntitiesDataProvider */
+    #[DataProvider('queryAndSearchResultVariationsWithEntitiesDataProvider')]
     public function testFindByQueryWithEntityFactory(
         QueryInterface $query,
         array $esResult,
@@ -59,37 +60,37 @@ final class RepositoryFindByQueryTest extends AbstractRepositoryTestCase
         }
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('search')
             ->with($rawParams)
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $repository = $this->getRepository(['entity_factory' => $this->getEntityFactory()]);
+        $repository = $this->getRepository(['entity_factory' => new EntityFactoryStub()]);
 
         $result = $scroll
             ? $repository->findScrollableByQuery($query)
             : $repository->findByQuery($query);
 
-        $this->assertEquals($endResult, $result->asArray());
-        $this->assertEquals(self::DOCUMENT_COUNT, $result->getTotal());
+        self::assertEquals($endResult, $result->asArray());
+        self::assertEquals(self::DOCUMENT_COUNT, $result->getTotal());
         if ($scroll) {
-            $this->assertEquals(self::SCROLL_ID, $result->getScrollId());
+            self::assertEquals(self::SCROLL_ID, $result->getScrollId());
         } else {
-            $this->assertNull($result->getScrollId());
+            self::assertNull($result->getScrollId());
         }
 
         if ($result->getCount() > 0) {
             foreach ($result as $entity) {
-                $this->assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
+                self::assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
             }
         }
     }
 
-    /** @dataProvider queryAndSearchResultVariationsWithEntitiesDataProvider */
+    #[DataProvider('queryAndSearchResultVariationsWithEntitiesDataProvider')]
     public function testFindByQueryWithEntityClass(
         QueryInterface $query,
         array $esResult,
@@ -106,32 +107,32 @@ final class RepositoryFindByQueryTest extends AbstractRepositoryTestCase
         }
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('search')
             ->with($rawParams)
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $repository = $this->getRepository(['entity_class' => get_class($this->getEntityClassInstance())]);
+        $repository = $this->getRepository(['entity_class' => PersistableEntityStub::class]);
 
         $result = $scroll
             ? $repository->findScrollableByQuery($query)
             : $repository->findByQuery($query);
 
-        $this->assertEquals($endResult, $result->asArray());
-        $this->assertEquals(self::DOCUMENT_COUNT, $result->getTotal());
+        self::assertEquals($endResult, $result->asArray());
+        self::assertEquals(self::DOCUMENT_COUNT, $result->getTotal());
         if ($scroll) {
-            $this->assertEquals(self::SCROLL_ID, $result->getScrollId());
+            self::assertEquals(self::SCROLL_ID, $result->getScrollId());
         } else {
-            $this->assertNull($result->getScrollId());
+            self::assertNull($result->getScrollId());
         }
 
         if ($result->getCount() > 0) {
             foreach ($result as $entity) {
-                $this->assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
+                self::assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
             }
         }
     }
@@ -139,21 +140,21 @@ final class RepositoryFindByQueryTest extends AbstractRepositoryTestCase
     public function testFindByQueryFails(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('search')
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
 
         try {
             $this->getRepository()->findByQuery(Query::create());
         } catch (ReadOperationException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertNull($e->getQuery());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertNull($e->getQuery());
         }
     }
 }

--- a/tests/Repository/RepositoryFindByScrollIdTest.php
+++ b/tests/Repository/RepositoryFindByScrollIdTest.php
@@ -6,16 +6,17 @@ namespace Kununu\Elasticsearch\Tests\Repository;
 use Exception;
 use Kununu\Elasticsearch\Exception\ReadOperationException;
 use Kununu\Elasticsearch\Repository\RepositoryConfiguration;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
 {
-    /** @dataProvider searchResultDataProvider */
+    #[DataProvider('searchResultDataProvider')]
     public function testFindByScrollId(array $esResult, mixed $endResult): void
     {
         $scrollId = 'foobar';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('scroll')
             ->with([
                 'body'   => [
@@ -26,22 +27,22 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $result = $this->getRepository()->findByScrollId($scrollId);
 
-        $this->assertEquals($endResult, $result->asArray());
+        self::assertEquals($endResult, $result->asArray());
     }
 
-    /** @dataProvider searchResultDataProvider */
+    #[DataProvider('searchResultDataProvider')]
     public function testFindByScrollIdCanOverrideScrollContextKeepalive(array $esResult, array $endResult): void
     {
         $scrollId = 'foobar';
         $keepalive = '20m';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('scroll')
             ->with([
                 'body'   => [
@@ -52,21 +53,21 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
             ->willReturn($esResult);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $result = $this->getRepository()->findByScrollId($scrollId, $keepalive);
 
-        $this->assertEquals($endResult, $result->asArray());
+        self::assertEquals($endResult, $result->asArray());
     }
 
-    /** @dataProvider searchResultWithEntitiesDataProvider */
+    #[DataProvider('searchResultWithEntitiesDataProvider')]
     public function testFindByScrollIdWithEntityFactory(array $esResult, array $endResult): void
     {
         $scrollId = 'foobar';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('scroll')
             ->with([
                 'body'   => [
@@ -77,29 +78,29 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
             ->willReturn(array_merge($esResult, ['_scroll_id' => $scrollId]));
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $result = $this->getRepository(['entity_factory' => $this->getEntityFactory()])->findByScrollId($scrollId);
+        $result = $this->getRepository(['entity_factory' => new EntityFactoryStub()])->findByScrollId($scrollId);
 
-        $this->assertEquals($endResult, $result->asArray());
-        $this->assertEquals(self::DOCUMENT_COUNT, $result->getTotal());
-        $this->assertEquals($scrollId, $result->getScrollId());
+        self::assertEquals($endResult, $result->asArray());
+        self::assertEquals(self::DOCUMENT_COUNT, $result->getTotal());
+        self::assertEquals($scrollId, $result->getScrollId());
 
         if ($result->getCount() > 0) {
             foreach ($result as $entity) {
-                $this->assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
+                self::assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
             }
         }
     }
 
-    /** @dataProvider searchResultWithEntitiesDataProvider */
+    #[DataProvider('searchResultWithEntitiesDataProvider')]
     public function testFindByScrollIdWithEntityClass(array $esResult, array $endResult): void
     {
         $scrollId = 'foobar';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('scroll')
             ->with([
                 'body'   => [
@@ -110,20 +111,20 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
             ->willReturn(array_merge($esResult, ['_scroll_id' => $scrollId]));
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $result = $this
-            ->getRepository(['entity_class' => $this->getEntityClass()])
+            ->getRepository(['entity_class' => PersistableEntityStub::class])
             ->findByScrollId($scrollId);
 
-        $this->assertEquals($endResult, $result->asArray());
-        $this->assertEquals(self::DOCUMENT_COUNT, $result->getTotal());
-        $this->assertEquals($scrollId, $result->getScrollId());
+        self::assertEquals($endResult, $result->asArray());
+        self::assertEquals(self::DOCUMENT_COUNT, $result->getTotal());
+        self::assertEquals($scrollId, $result->getScrollId());
 
         if ($result->getCount() > 0) {
             foreach ($result as $entity) {
-                $this->assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
+                self::assertEquals(['_index' => self::INDEX['read'], '_score' => 77], $entity->_meta);
             }
         }
     }
@@ -133,7 +134,7 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
         $scrollId = 'foobar';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('scroll')
             ->with([
                 'body' => [
@@ -144,16 +145,16 @@ final class RepositoryFindByScrollIdTest extends AbstractRepositoryTestCase
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
 
         try {
             $this->getRepository()->findByScrollId($scrollId);
         } catch (ReadOperationException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertNull($e->getQuery());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertNull($e->getQuery());
         }
     }
 }

--- a/tests/Repository/RepositoryFindScrollableByQueryTest.php
+++ b/tests/Repository/RepositoryFindScrollableByQueryTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 namespace Kununu\Elasticsearch\Tests\Repository;
 
 use Kununu\Elasticsearch\Query\Query;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class RepositoryFindScrollableByQueryTest extends AbstractRepositoryTestCase
 {
-    /** @dataProvider searchResultDataProvider */
+    #[DataProvider('searchResultDataProvider')]
     public function testFindScrollableByQueryCanOverrideScrollContextKeepalive(array $esResult, mixed $endResult): void
     {
         $query = Query::create();
@@ -20,13 +21,13 @@ final class RepositoryFindScrollableByQueryTest extends AbstractRepositoryTestCa
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('search')
             ->with($rawParams)
             ->willReturn($esResult);
 
         $result = $this->getRepository()->findScrollableByQuery($query, $keepalive);
 
-        $this->assertEquals($endResult, $result->asArray());
+        self::assertEquals($endResult, $result->asArray());
     }
 }

--- a/tests/Repository/RepositorySaveBulkTest.php
+++ b/tests/Repository/RepositorySaveBulkTest.php
@@ -7,7 +7,7 @@ use Exception;
 use Kununu\Elasticsearch\Exception\BulkException;
 use Kununu\Elasticsearch\Exception\RepositoryConfigurationException;
 use Kununu\Elasticsearch\Repository\Repository;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use TypeError;
 
@@ -23,7 +23,7 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bulk')
             ->with([
                 'index' => self::INDEX['write'],
@@ -40,7 +40,7 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository()->saveBulk($documents);
@@ -56,7 +56,7 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bulk')
             ->with([
                 'index'   => self::INDEX['write'],
@@ -74,7 +74,7 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository(['force_refresh_on_write' => true])->saveBulk($documents);
@@ -83,7 +83,7 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
     public function testSaveBulkObjectsWithEntitySerializer(): void
     {
         $documents = [];
-        for ($ii = 0; $ii < 3; $ii++) {
+        for ($ii = 0; $ii < 3; ++$ii) {
             $document = new stdClass();
             $document->property_a = 'a' . $ii;
             $document->property_b = 'b' . $ii;
@@ -91,7 +91,7 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
         }
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bulk')
             ->with([
                 'index' => self::INDEX['write'],
@@ -106,7 +106,7 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository(['entity_serializer' => new EntitySerializerStub()])->saveBulk($documents);
@@ -115,15 +115,15 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
     public function testSaveBulkObjectsWithEntityClass(): void
     {
         $documents = [];
-        for ($ii = 0; $ii < 3; $ii++) {
-            $document = $this->getEntityClassInstance();
+        for ($ii = 0; $ii < 3; ++$ii) {
+            $document = new PersistableEntityStub();
             $document->property_a = 'a' . $ii;
             $document->property_b = 'b' . $ii;
             $documents['doc_' . $ii] = $document;
         }
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bulk')
             ->with([
                 'index' => self::INDEX['write'],
@@ -138,11 +138,11 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this
-            ->getRepository(['entity_class' => $this->getEntityClass()])
+            ->getRepository(['entity_class' => PersistableEntityStub::class])
             ->saveBulk($documents);
     }
 
@@ -154,7 +154,7 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
         $this->getRepository()->saveBulk([self::ID => new stdClass()]);
     }
 
-    /** @dataProvider invalidDataTypesForSaveAndUpsertDataProvider */
+    #[DataProvider('invalidDataTypesForSaveAndUpsertDataProvider')]
     public function testSaveBulkFailsWithInvalidDataType(mixed $entity): void
     {
         $this->expectException(TypeError::class);
@@ -176,7 +176,7 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bulk')
             ->with(
                 [
@@ -187,16 +187,16 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error')
             ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
 
         try {
             $this->getRepository()->saveBulk($documents);
         } catch (BulkException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertEquals($expectedOperations, $e->getOperations());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertEquals($expectedOperations, $e->getOperations());
         }
     }
 
@@ -209,7 +209,7 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bulk')
             ->with([
                 'index' => self::INDEX['write'],
@@ -220,13 +220,13 @@ final class RepositorySaveBulkTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $manager = new class($this->clientMock, ['index_write' => self::INDEX['write']]) extends Repository {
             protected function postSaveBulk(array $entities): void
             {
-                TestCase::assertEquals(
+                AbstractRepositoryTestCase::assertEquals(
                     [
                         AbstractRepositoryTestCase::ID => [
                             'whatever' => 'just some data',

--- a/tests/Repository/RepositorySaveObjectTest.php
+++ b/tests/Repository/RepositorySaveObjectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Kununu\Elasticsearch\Tests\Repository;
 
 use Kununu\Elasticsearch\Exception\RepositoryConfigurationException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use TypeError;
 
@@ -16,7 +17,7 @@ final class RepositorySaveObjectTest extends AbstractRepositoryTestCase
         $document->property_b = 'b';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('index')
             ->with([
                 'index' => self::INDEX['write'],
@@ -28,7 +29,7 @@ final class RepositorySaveObjectTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository(['entity_serializer' => new EntitySerializerStub()])->save(self::ID, $document);
@@ -36,12 +37,12 @@ final class RepositorySaveObjectTest extends AbstractRepositoryTestCase
 
     public function testSaveObjectWithEntityClass(): void
     {
-        $document = $this->getEntityClassInstance();
+        $document = new PersistableEntityStub();
         $document->property_a = 'a';
         $document->property_b = 'b';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('index')
             ->with([
                 'index' => self::INDEX['write'],
@@ -53,10 +54,10 @@ final class RepositorySaveObjectTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->getRepository(['entity_class' => $this->getEntityClass()])->save(self::ID, $document);
+        $this->getRepository(['entity_class' => PersistableEntityStub::class])->save(self::ID, $document);
     }
 
     public function testSaveObjectFailsWithoutEntitySerializerAndEntityClass(): void
@@ -67,7 +68,7 @@ final class RepositorySaveObjectTest extends AbstractRepositoryTestCase
         $this->getRepository()->save(self::ID, new stdClass());
     }
 
-    /** @dataProvider invalidDataTypesForSaveAndUpsertDataProvider */
+    #[DataProvider('invalidDataTypesForSaveAndUpsertDataProvider')]
     public function testSaveFailsWithInvalidDataType(mixed $entity): void
     {
         $this->expectException(TypeError::class);

--- a/tests/Repository/RepositorySaveTest.php
+++ b/tests/Repository/RepositorySaveTest.php
@@ -6,7 +6,6 @@ namespace Kununu\Elasticsearch\Tests\Repository;
 use Exception;
 use Kununu\Elasticsearch\Exception\UpsertException;
 use Kununu\Elasticsearch\Repository\Repository;
-use PHPUnit\Framework\TestCase;
 
 final class RepositorySaveTest extends AbstractRepositoryTestCase
 {
@@ -17,7 +16,7 @@ final class RepositorySaveTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('index')
             ->with([
                 'index' => self::INDEX['write'],
@@ -26,7 +25,7 @@ final class RepositorySaveTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository()->save(self::ID, $document);
@@ -39,7 +38,7 @@ final class RepositorySaveTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('index')
             ->with([
                 'index'   => self::INDEX['write'],
@@ -49,7 +48,7 @@ final class RepositorySaveTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository(['force_refresh_on_write' => true])->save(self::ID, $document);
@@ -62,7 +61,7 @@ final class RepositorySaveTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('index')
             ->with([
                 'index' => self::INDEX['write'],
@@ -72,16 +71,17 @@ final class RepositorySaveTest extends AbstractRepositoryTestCase
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
+            ->expects(self::once())
             ->method('error')
             ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
 
         try {
             $this->getRepository()->save(self::ID, $document);
         } catch (UpsertException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertEquals(self::ID, $e->getDocumentId());
-            $this->assertEquals($document, $e->getDocument());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertEquals(self::ID, $e->getDocumentId());
+            self::assertEquals($document, $e->getDocument());
         }
     }
 
@@ -92,7 +92,7 @@ final class RepositorySaveTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('index')
             ->with([
                 'index' => self::INDEX['write'],
@@ -101,14 +101,14 @@ final class RepositorySaveTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $manager = new class($this->clientMock, ['index_write' => self::INDEX['write']]) extends Repository {
             protected function postSave(string $id, array $document): void
             {
-                TestCase::assertEquals(AbstractRepositoryTestCase::ID, $id);
-                TestCase::assertEquals(['whatever' => 'just some data'], $document);
+                AbstractRepositoryTestCase::assertEquals(AbstractRepositoryTestCase::ID, $id);
+                AbstractRepositoryTestCase::assertEquals(['whatever' => 'just some data'], $document);
             }
         };
 

--- a/tests/Repository/RepositoryUpdateByQueryTest.php
+++ b/tests/Repository/RepositoryUpdateByQueryTest.php
@@ -41,7 +41,7 @@ final class RepositoryUpdateByQueryTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateByQuery')
             ->with([
                 'index' => self::INDEX['write'],
@@ -59,10 +59,10 @@ final class RepositoryUpdateByQueryTest extends AbstractRepositoryTestCase
             ->willReturn($responseBody);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->assertEquals($responseBody, $this->getRepository()->updateByQuery($query, $updateScript));
+        self::assertEquals($responseBody, $this->getRepository()->updateByQuery($query, $updateScript));
     }
 
     public function testUpdateByQueryWithForcedRefresh(): void
@@ -96,7 +96,7 @@ final class RepositoryUpdateByQueryTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateByQuery')
             ->with([
                 'index'   => self::INDEX['write'],
@@ -115,30 +115,31 @@ final class RepositoryUpdateByQueryTest extends AbstractRepositoryTestCase
             ->willReturn($responseBody);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $repository = $this->getRepository(['force_refresh_on_write' => true]);
 
-        $this->assertEquals($responseBody, $repository->updateByQuery($query, $updateScript));
+        self::assertEquals($responseBody, $repository->updateByQuery($query, $updateScript));
     }
 
     public function testUpdateByQueryFails(): void
     {
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('updateByQuery')
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
+            ->expects(self::once())
             ->method('error')
             ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
 
         try {
             $this->getRepository()->updateByQuery(Query::create(), ['script' => []]);
         } catch (WriteOperationException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
         }
     }
 }

--- a/tests/Repository/RepositoryUpdateTest.php
+++ b/tests/Repository/RepositoryUpdateTest.php
@@ -6,6 +6,7 @@ namespace Kununu\Elasticsearch\Tests\Repository;
 use Exception;
 use Kununu\Elasticsearch\Exception\RepositoryConfigurationException;
 use Kununu\Elasticsearch\Exception\UpdateException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use TypeError;
 
@@ -18,7 +19,7 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with([
                 'index' => self::INDEX['write'],
@@ -29,7 +30,7 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository()->update(self::ID, $document);
@@ -42,7 +43,7 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with([
                 'index'   => self::INDEX['write'],
@@ -54,7 +55,7 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository(['force_refresh_on_write' => true])->update(self::ID, $document);
@@ -67,7 +68,7 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
         $document->property_b = 'b';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with([
                 'index' => self::INDEX['write'],
@@ -81,7 +82,7 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->getRepository(['entity_serializer' => new EntitySerializerStub()])->update(self::ID, $document);
@@ -89,12 +90,12 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
 
     public function testUpdateObjectWithEntityClass(): void
     {
-        $document = $this->getEntityClassInstance();
+        $document = new PersistableEntityStub();
         $document->property_a = 'a';
         $document->property_b = 'b';
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with([
                 'index' => self::INDEX['write'],
@@ -108,10 +109,10 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
             ]);
 
         $this->loggerMock
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
-        $this->getRepository(['entity_class' => $this->getEntityClass()])->update(self::ID, $document);
+        $this->getRepository(['entity_class' => PersistableEntityStub::class])->update(self::ID, $document);
     }
 
     public function testUpdateObjectFailsWithoutEntitySerializerAndEntityClass(): void
@@ -122,7 +123,7 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
         $this->getRepository()->update(self::ID, new stdClass());
     }
 
-    /** @dataProvider invalidDataTypesForSaveAndUpsertDataProvider */
+    #[DataProvider('invalidDataTypesForSaveAndUpsertDataProvider')]
     public function testUpdateFailsWithInvalidDataType(mixed $entity): void
     {
         $this->expectException(TypeError::class);
@@ -137,7 +138,7 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
         ];
 
         $this->clientMock
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('update')
             ->with([
                 'index' => self::INDEX['write'],
@@ -149,16 +150,17 @@ final class RepositoryUpdateTest extends AbstractRepositoryTestCase
             ->willThrowException(new Exception(self::ERROR_MESSAGE));
 
         $this->loggerMock
+            ->expects(self::once())
             ->method('error')
             ->with(self::ERROR_PREFIX . self::ERROR_MESSAGE);
 
         try {
             $this->getRepository()->update(self::ID, $document);
         } catch (UpdateException $e) {
-            $this->assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
-            $this->assertEquals(0, $e->getCode());
-            $this->assertEquals(self::ID, $e->getDocumentId());
-            $this->assertEquals($document, $e->getDocument());
+            self::assertEquals(self::ERROR_PREFIX . self::ERROR_MESSAGE, $e->getMessage());
+            self::assertEquals(0, $e->getCode());
+            self::assertEquals(self::ID, $e->getDocumentId());
+            self::assertEquals($document, $e->getDocument());
         }
     }
 }

--- a/tests/Result/AggregationResultSetTest.php
+++ b/tests/Result/AggregationResultSetTest.php
@@ -6,6 +6,7 @@ namespace Kununu\Elasticsearch\Tests\Result;
 use Kununu\Elasticsearch\Result\AggregationResult;
 use Kununu\Elasticsearch\Result\AggregationResultSet;
 use Kununu\Elasticsearch\Result\ResultIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AggregationResultSetTest extends TestCase
@@ -13,12 +14,12 @@ final class AggregationResultSetTest extends TestCase
     public static function createDataProvider(): array
     {
         return [
-            'empty result' => [
+            'empty_result'     => [
                 'rawResult' => [],
             ],
-            'non-empty result' => [
+            'non_empty_result' => [
                 'rawResult' => [
-                    'my_first_agg' => [
+                    'my_first_agg'  => [
                         'value' => 0.1,
                     ],
                     'my_second_agg' => [
@@ -30,15 +31,16 @@ final class AggregationResultSetTest extends TestCase
         ];
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testCreate(array $rawResult): void
     {
         $result = AggregationResultSet::create($rawResult);
-        $this->assertCount(count($rawResult), $result->getResults());
+
+        self::assertCount(count($rawResult), $result->getResults());
         foreach ($result->getResults() as $singleResultName => $singleResult) {
-            $this->assertInstanceOf(AggregationResult::class, $singleResult);
-            $this->assertEquals($singleResultName, $singleResult->getName());
-            $this->assertEquals($rawResult[$singleResultName], $singleResult->getFields());
+            self::assertInstanceOf(AggregationResult::class, $singleResult);
+            self::assertEquals($singleResultName, $singleResult->getName());
+            self::assertEquals($rawResult[$singleResultName], $singleResult->getFields());
         }
     }
 
@@ -46,24 +48,24 @@ final class AggregationResultSetTest extends TestCase
     {
         $result = AggregationResultSet::create();
 
-        $this->assertNull($result->getDocuments());
+        self::assertNull($result->getDocuments());
 
         $documentIterator = ResultIterator::create();
 
         $result->setDocuments($documentIterator);
 
-        $this->assertEquals($documentIterator, $result->getDocuments());
+        self::assertEquals($documentIterator, $result->getDocuments());
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testGetResultByName(array $rawResult): void
     {
         $result = AggregationResultSet::create($rawResult);
 
         foreach ($result->getResults() as $singleResultName => $singleResult) {
-            $this->assertEquals($singleResult, $result->getResultByName($singleResultName));
+            self::assertEquals($singleResult, $result->getResultByName($singleResultName));
         }
 
-        $this->assertNull($result->getResultByName('this_aggregation_does_not_exist'));
+        self::assertNull($result->getResultByName('this_aggregation_does_not_exist'));
     }
 }

--- a/tests/Result/AggregationResultTest.php
+++ b/tests/Result/AggregationResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Kununu\Elasticsearch\Tests\Result;
 
 use Kununu\Elasticsearch\Result\AggregationResult;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AggregationResultTest extends TestCase
@@ -11,52 +12,56 @@ final class AggregationResultTest extends TestCase
     public static function createDataProvider(): array
     {
         return [
-            'empty name, empty fields'         => [
+            'empty_name_empty_fields'         => [
                 'name'   => '',
                 'fields' => [],
             ],
-            'non-empty name, empty fields'     => [
+            'non_empty_name_empty_fields'     => [
                 'name'   => 'my_agg',
                 'fields' => [],
             ],
-            'empty name, non-empty fields'     => [
+            'empty_name_non_empty_fields'     => [
                 'name'   => '',
                 'fields' => ['some' => 'thing', 'foo' => 'bar'],
             ],
-            'non-empty name, non-empty fields' => [
+            'non_empty_name_non_empty_fields' => [
                 'name'   => 'my_agg',
                 'fields' => ['some' => 'thing', 'foo' => 'bar'],
             ],
         ];
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testCreate(string $name, array $fields): void
     {
         $result = AggregationResult::create($name, $fields);
-        $this->assertEquals([$name => $fields], $result->toArray());
+
+        self::assertEquals([$name => $fields], $result->toArray());
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testGetName(string $name, array $fields): void
     {
         $result = AggregationResult::create($name, $fields);
-        $this->assertEquals($name, $result->getName());
+
+        self::assertEquals($name, $result->getName());
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testGetFields(string $name, array $fields): void
     {
         $result = AggregationResult::create($name, $fields);
-        $this->assertEquals($fields, $result->getFields());
+
+        self::assertEquals($fields, $result->getFields());
     }
 
     public function testGetField(): void
     {
         $result = AggregationResult::create('my_agg', ['some' => 'thing', 'foo' => 'bar']);
-        $this->assertEquals('thing', $result->get('some'));
-        $this->assertEquals('bar', $result->get('foo'));
-        $this->assertNull($result->get('this_field_does_not_exist'));
+
+        self::assertEquals('thing', $result->get('some'));
+        self::assertEquals('bar', $result->get('foo'));
+        self::assertNull($result->get('this_field_does_not_exist'));
     }
 
     public function testGetBuckets(): void
@@ -65,13 +70,15 @@ final class AggregationResultTest extends TestCase
             'my_agg',
             ['buckets' => ['a' => ['first_bucket'], 'b' => ['second_bucket']]]
         );
-        $this->assertEquals(['a' => ['first_bucket'], 'b' => ['second_bucket']], $result->getBuckets());
+
+        self::assertEquals(['a' => ['first_bucket'], 'b' => ['second_bucket']], $result->getBuckets());
 
         $result = AggregationResult::create(
             'my_agg',
             []
         );
-        $this->assertNull($result->getBuckets());
+
+        self::assertNull($result->getBuckets());
     }
 
     public function getValue(): void
@@ -80,12 +87,14 @@ final class AggregationResultTest extends TestCase
             'my_agg',
             ['value' => 0.1]
         );
-        $this->assertEquals(0.1, $result->getValue());
+
+        self::assertEquals(0.1, $result->getValue());
 
         $result = AggregationResult::create(
             'my_agg',
             []
         );
-        $this->assertNull($result->getValue());
+
+        self::assertNull($result->getValue());
     }
 }

--- a/tests/Result/ResultIteratorTest.php
+++ b/tests/Result/ResultIteratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Kununu\Elasticsearch\Tests\Result;
 
 use Kununu\Elasticsearch\Result\ResultIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -12,20 +13,21 @@ final class ResultIteratorTest extends TestCase
     public static function createDataProvider(): array
     {
         return [
-            'empty array'     => [
+            'empty_array'     => [
                 'input' => [],
             ],
-            'non-empty array' => [
+            'non_empty_array' => [
                 'input' => ['some' => 'thing', 'foo' => 'bar'],
             ],
         ];
     }
 
-    /** @dataProvider createDataProvider */
+    #[DataProvider('createDataProvider')]
     public function testCreate(array $input): void
     {
         $iterator = ResultIterator::create($input);
-        $this->assertEquals($input, $iterator->asArray());
+
+        self::assertEquals($input, $iterator->asArray());
     }
 
     public function testIterate(): void
@@ -38,9 +40,9 @@ final class ResultIteratorTest extends TestCase
             ['four'  => 4],
         ]);
 
-        $this->assertEquals(['zero' => 0], $iterator->current());
-        $this->assertEquals(0, $iterator->key());
-        $this->assertTrue($iterator->valid());
+        self::assertEquals(['zero' => 0], $iterator->current());
+        self::assertEquals(0, $iterator->key());
+        self::assertTrue($iterator->valid());
     }
 
     public function testArrayAccess(): void
@@ -55,89 +57,103 @@ final class ResultIteratorTest extends TestCase
         $initialCount = count($input);
         $iterator = new ResultIterator($input);
 
-        $this->assertCount($initialCount, $iterator);
-        $this->assertEquals($initialCount, $iterator->getCount());
-        $this->assertEquals($initialCount, $iterator->count());
+        self::assertCount($initialCount, $iterator);
+        self::assertEquals($initialCount, $iterator->getCount());
+        self::assertEquals($initialCount, $iterator->count());
 
-        for ($ii = 0; $ii < count($input); $ii++) {
-            $this->assertTrue($iterator->offsetExists($ii));
-            $this->assertEquals($input[$ii], $iterator->offsetGet($ii));
-            $this->assertEquals($input[$ii], $iterator[$ii]);
+        for ($ii = 0; $ii < count($input); ++$ii) {
+            self::assertTrue($iterator->offsetExists($ii));
+            self::assertEquals($input[$ii], $iterator->offsetGet($ii));
+            self::assertEquals($input[$ii], $iterator[$ii]);
         }
 
         foreach ($iterator as $ii => $element) {
-            $this->assertEquals($input[$ii], $element);
+            self::assertEquals($input[$ii], $element);
         }
 
         $iterator->offsetUnset(0);
-        $this->assertCount($initialCount - 1, $iterator);
-        $this->assertNull($iterator[0]);
+        self::assertCount($initialCount - 1, $iterator);
+        self::assertNull($iterator[0]);
 
         unset($iterator[1]);
-        $this->assertCount($initialCount - 2, $iterator);
-        $this->assertNull($iterator[1]);
+        self::assertCount($initialCount - 2, $iterator);
+        self::assertNull($iterator[1]);
 
         $iterator->offsetSet(2, ['two' => 2.2]);
-        $this->assertEquals(['two' => 2.2], $iterator[2]);
+        self::assertEquals(['two' => 2.2], $iterator[2]);
 
         $iterator[2] = ['two' => 2.3];
-        $this->assertEquals(['two' => 2.3], $iterator[2]);
+        self::assertEquals(['two' => 2.3], $iterator[2]);
 
         $iterator[6] = ['five' => 5];
-        $this->assertEquals(['five' => 5], $iterator[6]);
+        self::assertEquals(['five' => 5], $iterator[6]);
 
         $iterator[] = ['six' => 6];
-        $this->assertEquals(['six' => 6], $iterator[7]);
+        self::assertEquals(['six' => 6], $iterator[7]);
     }
 
     public function testTotal(): void
     {
         $iterator = ResultIterator::create();
-        $this->assertEquals(0, $iterator->getTotal());
+
+        self::assertEquals(0, $iterator->getTotal());
+
         $iterator->setTotal(100);
-        $this->assertEquals(100, $iterator->getTotal());
+
+        self::assertEquals(100, $iterator->getTotal());
 
         $iterator = ResultIterator::create(['some', 'thing']);
-        $this->assertEquals(0, $iterator->getTotal());
+
+        self::assertEquals(0, $iterator->getTotal());
+
         $iterator->setTotal(200);
-        $this->assertEquals(200, $iterator->getTotal());
+
+        self::assertEquals(200, $iterator->getTotal());
     }
 
     public function testScrollId(): void
     {
         $iterator = ResultIterator::create();
-        $this->assertNull($iterator->getScrollId());
+
+        self::assertNull($iterator->getScrollId());
+
         $iterator->setScrollId('my_scroll_id');
-        $this->assertEquals('my_scroll_id', $iterator->getScrollId());
+
+        self::assertEquals('my_scroll_id', $iterator->getScrollId());
 
         $iterator = ResultIterator::create(['some', 'thing']);
-        $this->assertEquals(0, $iterator->getTotal());
+
+        self::assertEquals(0, $iterator->getTotal());
+
         $iterator->setTotal(200);
-        $this->assertEquals(200, $iterator->getTotal());
+
+        self::assertEquals(200, $iterator->getTotal());
     }
 
     public function testPushArray(): void
     {
         $iterator = ResultIterator::create();
-        $this->assertEmpty($iterator->asArray());
-        $this->assertEquals(0, $iterator->getCount());
+
+        self::assertEmpty($iterator->asArray());
+        self::assertEquals(0, $iterator->getCount());
 
         $iterator->push(['some' => 'thing']);
 
-        $this->assertEquals([['some' => 'thing']], $iterator->asArray());
-        $this->assertEquals(1, $iterator->getCount());
+        self::assertEquals([['some' => 'thing']], $iterator->asArray());
+        self::assertEquals(1, $iterator->getCount());
     }
 
     public function testPushObject(): void
     {
         $iterator = ResultIterator::create();
-        $this->assertEmpty($iterator->asArray());
-        $this->assertEquals(0, $iterator->getCount());
+
+        self::assertEmpty($iterator->asArray());
+        self::assertEquals(0, $iterator->getCount());
 
         $iterator->push(new stdClass());
 
-        $this->assertEquals([new stdClass()], $iterator->asArray());
-        $this->assertEquals(1, $iterator->getCount());
+        self::assertEquals([new stdClass()], $iterator->asArray());
+        self::assertEquals(1, $iterator->getCount());
     }
 
     public function testFirstMatch(): void
@@ -151,7 +167,7 @@ final class ResultIteratorTest extends TestCase
             fn($element): bool => $element['foo'] === 'bar'
         );
 
-        $this->assertEquals(['foo' => 'bar', 'num' => 0], $firstFooBar);
+        self::assertEquals(['foo' => 'bar', 'num' => 0], $firstFooBar);
     }
 
     public function testFirstNoMatch(): void
@@ -165,7 +181,7 @@ final class ResultIteratorTest extends TestCase
             fn($element): bool => isset($element['bar']) && $element['bar'] === 'foo'
         );
 
-        $this->assertNull($firstBarFoo);
+        self::assertNull($firstBarFoo);
     }
 
     public function testFilter(): void
@@ -180,7 +196,7 @@ final class ResultIteratorTest extends TestCase
             fn($element) => isset($element['foo']) && $element['foo'] === 'bar'
         );
 
-        $this->assertEquals([['foo' => 'bar'], ['foo' => 'bar']], $allFooBars);
+        self::assertEquals([['foo' => 'bar'], ['foo' => 'bar']], $allFooBars);
     }
 
     public function testSome(): void
@@ -194,13 +210,13 @@ final class ResultIteratorTest extends TestCase
             fn($element) => isset($element['foo']) && $element['foo'] === 'bar'
         );
 
-        $this->assertTrue($thereAreFooBars);
+        self::assertTrue($thereAreFooBars);
 
         $thereAreBarFoos = $iterator->some(
             fn($element): bool => isset($element['bar']) && $element['bar'] === 'foo'
         );
 
-        $this->assertFalse($thereAreBarFoos);
+        self::assertFalse($thereAreBarFoos);
     }
 
     public function testEveryTrue(): void
@@ -214,7 +230,7 @@ final class ResultIteratorTest extends TestCase
             fn($element): bool => isset($element['foo']) && $element['foo'] === 'bar'
         );
 
-        $this->assertTrue($thereAreOnlyFooBars);
+        self::assertTrue($thereAreOnlyFooBars);
     }
 
     public function testEveryFalse(): void
@@ -228,37 +244,38 @@ final class ResultIteratorTest extends TestCase
             fn($element): bool => isset($element['bar']) && $element['bar'] === 'foo'
         );
 
-        $this->assertFalse($thereAreOnlyBarFoos);
+        self::assertFalse($thereAreOnlyBarFoos);
     }
 
     public function testEach(): void
     {
-        $mockBuilder = $this->getMockBuilder(stdClass::class)->addMethods(['someMethod']);
-        $mocks = [
-            $mockBuilder->getMock(),
-            $mockBuilder->getMock(),
-            $mockBuilder->getMock(),
-        ];
+        $calls = 0;
+        $stubs = [];
+        for ($i = 0; $i < 3; ++$i) {
+            $stubs[$i] = new class() {
+                public int $call = 0;
 
-        foreach ($mocks as $mock) {
-            $mock
-                ->expects($this->once())
-                ->method('someMethod');
+                public function someMethod(int $call): void
+                {
+                    $this->call = $call;
+                }
+            };
         }
 
-        $calls = 0;
-
-        $iterator = ResultIterator::create($mocks);
+        $iterator = ResultIterator::create($stubs);
 
         $iterator->each(
             function($element) use (&$calls): void {
-                $calls++;
+                ++$calls;
 
-                $element->someMethod();
+                $element->someMethod($calls);
             }
         );
 
-        $this->assertEquals(count($mocks), $calls);
+        self::assertEquals(count($stubs), $calls);
+        foreach ($stubs as $i => $stub) {
+            self::assertEquals($i + 1, $stub->call);
+        }
     }
 
     public function testMap(): void
@@ -273,7 +290,7 @@ final class ResultIteratorTest extends TestCase
             fn($element): array => array_flip($element)
         );
 
-        $this->assertEquals([['bar' => 'foo'], ['bar' => 'foo'], ['foo' => 'bar']], $flipped);
+        self::assertEquals([['bar' => 'foo'], ['bar' => 'foo'], ['foo' => 'bar']], $flipped);
     }
 
     public function testReduce(): void
@@ -289,6 +306,6 @@ final class ResultIteratorTest extends TestCase
             0
         );
 
-        $this->assertEquals(2, $numberOfFooBars);
+        self::assertEquals(2, $numberOfFooBars);
     }
 }

--- a/tests/Util/ConstantContainerTraitTest.php
+++ b/tests/Util/ConstantContainerTraitTest.php
@@ -10,12 +10,12 @@ final class ConstantContainerTraitTest extends TestCase
 {
     public function testAll(): void
     {
-        $this->assertEquals(['first', 'second', 'third'], $this->getConstantContainer()->all());
+        self::assertEquals(['first', 'second', 'third'], $this->getConstantContainer()->all());
     }
 
     public function testAllPreserveKeys(): void
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['FIRST' => 'first', 'SECOND' => 'second', 'THIRD' => 'third'],
             $this->getConstantContainer()->all(true)
         );
@@ -24,16 +24,18 @@ final class ConstantContainerTraitTest extends TestCase
     public function testHasConstantTrue(): void
     {
         $container = $this->getConstantContainer();
+
         foreach ($container->all() as $constant) {
-            $this->assertTrue($container->hasConstant($constant));
+            self::assertTrue($container->hasConstant($constant));
         }
     }
 
     public function testHasConstantFalse(): void
     {
         $container = $this->getConstantContainer();
-        $this->assertFalse($container->hasConstant(''));
-        $this->assertFalse($container->hasConstant('foo'));
+
+        self::assertFalse($container->hasConstant(''));
+        self::assertFalse($container->hasConstant('foo'));
     }
 
     private function getConstantContainer(): object

--- a/tests/Util/LoggerAwareTraitTest.php
+++ b/tests/Util/LoggerAwareTraitTest.php
@@ -19,24 +19,26 @@ final class LoggerAwareTraitTest extends TestCase
 
         $loggerAwareObject->setLogger($logger);
 
-        $this->assertEquals($logger, $loggerAwareObject->publiclyGetLogger());
+        self::assertEquals($logger, $loggerAwareObject->getLogger());
     }
 
     public function testGetNullLoggerAsDefault(): void
     {
         $loggerAwareObject = $this->getLoggerAwareObject();
 
-        $this->assertInstanceOf(NullLogger::class, $loggerAwareObject->publiclyGetLogger());
+        self::assertInstanceOf(NullLogger::class, $loggerAwareObject->getLogger());
     }
 
     public function getLoggerAwareObject(): LoggerAwareInterface
     {
         return new class() implements LoggerAwareInterface {
-            use LoggerAwareTrait;
+            use LoggerAwareTrait {
+                getLogger as traitGetLogger;
+            }
 
-            public function publiclyGetLogger()
+            public function getLogger(): LoggerInterface
             {
-                return $this->getLogger();
+                return $this->traitGetLogger();
             }
         };
     }

--- a/tests/Util/OptionableTraitTest.php
+++ b/tests/Util/OptionableTraitTest.php
@@ -11,15 +11,16 @@ final class OptionableTraitTest extends TestCase
 {
     public const OPTION_A = 'option_a';
     public const OPTION_B = 'option_b';
+
     protected const NOT_AN_OPTION = 'foobar';
 
     public function testGetNotSetOption(): void
     {
         $optionable = $this->getOptionableObject();
 
-        $this->assertNull($optionable->getOption(self::OPTION_A));
-        $this->assertNull($optionable->getOption(self::OPTION_B));
-        $this->assertEmpty($optionable->getOptions());
+        self::assertNull($optionable->getOption(self::OPTION_A));
+        self::assertNull($optionable->getOption(self::OPTION_B));
+        self::assertEmpty($optionable->getOptions());
     }
 
     public function testSetAndGet(): void
@@ -30,9 +31,9 @@ final class OptionableTraitTest extends TestCase
 
         $optionable->setOption(self::OPTION_A, $myOption);
 
-        $this->assertEquals($myOption, $optionable->getOption(self::OPTION_A));
-        $this->assertNull($optionable->getOption(self::OPTION_B));
-        $this->assertEquals([self::OPTION_A => $myOption], $optionable->getOptions());
+        self::assertEquals($myOption, $optionable->getOption(self::OPTION_A));
+        self::assertNull($optionable->getOption(self::OPTION_B));
+        self::assertEquals([self::OPTION_A => $myOption], $optionable->getOptions());
     }
 
     public function testSetNull(): void
@@ -41,9 +42,9 @@ final class OptionableTraitTest extends TestCase
 
         $optionable->setOption(self::OPTION_A, null);
 
-        $this->assertNull($optionable->getOption(self::OPTION_A));
-        $this->assertNull($optionable->getOption(self::OPTION_B));
-        $this->assertEmpty($optionable->getOptions());
+        self::assertNull($optionable->getOption(self::OPTION_A));
+        self::assertNull($optionable->getOption(self::OPTION_B));
+        self::assertEmpty($optionable->getOptions());
     }
 
     public function testGetUnknownOption(): void


### PR DESCRIPTION
- Drop support for PHP 8.0 - PHP 8.1 is now the minimum version
- Upgrade PHPUnit to version 10.5
- Refactor some code to take advantage of PHP 8.1 features (read-only properties)
- Fix tests that used deprecated/removed features on PHPUnit 10.5
- Refactor tests to be more PHPUnit 10.5 compliant (e.g. using attributes for data providers, make all data providers static, etc.)
- Update versions of continuous integration components