### PR TITLE
docs: add kun-init 4-file documentation structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+## What this is
+
+`kununu/elasticsearch` is a PHP library for simplified querying and usage of Elasticsearch/OpenSearch at kununu. It provides a fluent query language, Repositories that encapsulate index-specific logic, and an `IndexManager` for common index management. It is consumed by other projects via Composer and makes them independent of the underlying client library.
+
+## Domain
+
+- **Repositories** — encapsulate Elasticsearch/OpenSearch logic for a specific index and execute queries against it.
+- **Queries** — an abstracted query language (`Query`, `RawQuery`) over the Elasticsearch Query DSL.
+- **IndexManager** — creating indices and managing aliases.
+- **Results** — typed result objects returned by repository operations.
+
+## Code layout
+
+- `src/Repository/` — Repository implementations and interfaces.
+- `src/Query/` — query language (criteria, aggregations, `Query`, `RawQuery`).
+- `src/IndexManagement/` — `IndexManager` and related interfaces.
+- `src/Result/` — result value objects.
+- `src/Exception/` — package exceptions.
+- `src/Util/` — internal helpers.
+- `tests/` — PHPUnit tests (`Kununu\Elasticsearch\Tests\`).
+- `doc/` — deep documentation per feature (Repository, Query, RawQuery, IndexManager, Results).
+
+## Quality gates
+
+Run via Composer scripts (defined in `composer.json` `scripts`):
+
+- `composer cs` — PHP CS Fixer with kununu code standards.
+- `composer sniffer` — PHP_CodeSniffer.
+- `composer phpstan` — PHPStan.
+- `composer rector` — Rector (dry-run, CI rules).
+- `composer test` — PHPUnit.
+
+CI additionally runs `composer-dependency-analyser`, `composer-require-checker`, and `composer-normalize`, then a SonarCloud scan. See `.github/workflows/continuous-integration.yml`.
+
+## Hard constraints
+
+- PHP version is pinned in `composer.json` (`require.php`).
+- PSR-4 autoloading: `Kununu\Elasticsearch\` maps to `src/`; tests map to `tests/`.
+- Coding standard is the kununu standard (extends PSR-12), enforced by `composer cs` and `composer sniffer`.
+- Semantic versioning ([SemVer 2.0.0](https://semver.org/)); changes to the public API require great consideration.
+- New behaviour requires tests and a `CHANGELOG.md` entry.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,43 @@ Contributions are more than **welcome** and will be fully **credited**.
 
 We accept contributions via Pull Requests on [GitHub](https://github.com/kununu/elasticsearch).
 
+## Development setup
+
+Requirements:
+
+- PHP as pinned in `composer.json` (`require.php`).
+- [Composer](https://getcomposer.org/).
+
+Install dependencies:
+
+```bash
+composer install
+```
+
+## Quality gates
+
+The following Composer scripts are available (defined in `composer.json` `scripts`):
+
+- `composer cs` — run PHP CS Fixer with the kununu code standards.
+- `composer sniffer` — run PHP_CodeSniffer.
+- `composer phpstan` — run PHPStan.
+- `composer rector` — run Rector in dry-run mode with CI rules (`composer rector-fix` to apply fixes).
+- `composer test` — run the test suite (`composer test-coverage` for a coverage report).
+
+Continuous Integration additionally runs `composer-dependency-analyser`, `composer-require-checker`, and `composer-normalize`, followed by a SonarCloud scan. See [`.github/workflows/continuous-integration.yml`](.github/workflows/continuous-integration.yml).
+
 ## Pull Requests
 
-- **[kununu Coding Standards](https://github.com/kununu/kununu-scripts)** - The kununu coding standards are an extension of the [PSR-12](https://www.php-fig.org/psr/psr-12/). Check out [kununu Coding Standards](https://github.com/kununu/kununu-scripts) for more details. In development mode the package [kununu-scripts](https://github.com/kununu/kununu-scripts) is already a dependency that expose commands that you can use to meet our standards.
+- **[kununu Coding Standards](https://github.com/kununu/code-tools)** — the kununu coding standards extend [PSR-12](https://www.php-fig.org/psr/psr-12/). In development mode the [`kununu/code-tools`](https://github.com/kununu/code-tools) package is already a dependency and exposes the commands used to meet these standards (`composer cs`, `composer sniffer`).
 
-- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it does not have tests.
+- **Add tests!** — to ensure a high quality code base, your code patch can't be accepted if it does not have tests.
 
-- **Document any change in behaviour** - Make sure the [CHANGELOG.md](CHANGELOG.md), [README.md](README.md) and any other relevant documentation are kept up-to-date.
+- **Document any change in behaviour** — make sure the [CHANGELOG.md](CHANGELOG.md), [README.md](README.md), and any other relevant documentation are kept up-to-date.
 
-- **Consider our release cycle** - Since we're using semantic versioning ([SemVer v2.0.0](http://semver.org/)). Changes to the API must be done with great consideration, and prevented if at all possible.
+- **Consider our release cycle** — we use semantic versioning ([SemVer 2.0.0](https://semver.org/)). Changes to the API must be done with great consideration, and prevented if at all possible.
 
-- **Create feature branches** - Master is the stable branch, create a new branch for each feature.
+- **Create feature branches** — `main` is the stable branch; create a new branch for each feature.
 
-- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+- **One pull request per feature** — if you want to do more than one thing, send multiple pull requests.
 
-- **Be respectful** - Be excellent to other contributors.
+- **Be respectful** — be excellent to other contributors.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This package aims to
  1. reduce cognitive load when interacting with Elasticsearch by providing an intuitive query language with a fluent interface while staying very close to Elasticsearch terminology
  2. make your project independent of the underlying client library
 
+## Installation
+
+```bash
+composer require kununu/elasticsearch
+```
+
 ## Quickstart
 It does not take a lot to get you up and running with Elasticsearch. All that's required is a `Repository` which can be used to execute requests (e.g. to save a document, query for documents, etc.)
 
@@ -15,6 +21,7 @@ declare(strict_types=1);
 
 use Elasticsearch\ClientBuilder;
 use Kununu\Elasticsearch\Query\Criteria\Filter;
+use Kununu\Elasticsearch\Query\Criteria\Operator;
 use Kununu\Elasticsearch\Query\Criteria\Search;
 use Kununu\Elasticsearch\Query\Query;
 use Kununu\Elasticsearch\Repository\Elasticsearch\Repository;


### PR DESCRIPTION
## What

Adds the kun-init 4-file documentation structure with strict, non-overlapping ownership:

- **README.md** — what the library is, `composer require` install, usage. Reconciled: added an Installation section and the missing `Operator` import in the Quickstart example.
- **AGENTS.md** — concise entry point: what it is, domain, code layout, quality gates, hard constraints.
- **CONTRIBUTING.md** — owns all dev workflow. Reconciled the existing file: added Development setup + Quality gates sections and corrected the stale `master` reference to `main`.
- **CLAUDE.md** — `@AGENTS.md`.

## Why

Consistent documentation entry points across kununu repos for both humans and coding agents.

## Notes

- Docs-only change; no source or behaviour changes.
- Quality gate commands reference the Composer `scripts`; the PHP version is left pinned in `composer.json`.

Ref: KUNAI-8